### PR TITLE
Update legislators.py to expect columns from live legislator DB table

### DIFF
--- a/app/legislators.py
+++ b/app/legislators.py
@@ -34,7 +34,7 @@ def get_and_clean_leg_data():
         # Query the database for bills and history
         legislators = query_table('ca_dev', 'legislator')
         legislators['chamber'] = np.where(legislators['chamber_id']==1,'Assembly','Senate') # change chamber id to actual chamber values
-        legislators = legislators.drop(['legislator_id','chamber_id'],axis=1) # drop these two columns
+        legislators = legislators.drop(['legislator_id','chamber_id', 'openstates_people_id'],axis=1) # drop these ID columns
         return legislators
     
     # Call the cached function to get the data


### PR DESCRIPTION
Legislators page now drops all backend columns to match the update to`ca_dev.legislator`which now [pulls directly from OpenStates](https://github.com/techequitycollaborative/ca-leg-tracker/blob/main/database-population/session_update.py) 