### PR TITLE
Added initial bill events field to bills page + removed coalition field

### DIFF
--- a/app/bills_topic.py
+++ b/app/bills_topic.py
@@ -29,10 +29,14 @@ st.write(
 ############################ LOAD AND PROCESS BILLS DATA #############################
 
 # Get data
-bills = get_data()
+bills, bill_events = get_data()
+
+# Add bill events to the bills table
+bills = bills.merge(bill_events[['bill_id', 'upcoming_comm_mtg','referred_committee']], on='bill_id', how='left')
 
 # Minor data processing 
-bills['date_introduced'] = pd.to_datetime(bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
+bills['date_introduced'] = pd.to_datetime(bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestamp from date introduced
+bills['upcoming_comm_mtg'] = pd.to_datetime(bills['upcoming_comm_mtg']).dt.strftime('%Y-%m-%d') # Remove timestamp from upcoming committee meeting date
 bills = get_bill_topics(bills, keyword_dict= keywords)  # Get bill topics
 bills['bill_history'] = bills['bill_history'].apply(format_bill_history) #Format bill history
 

--- a/app/db/query.py
+++ b/app/db/query.py
@@ -72,10 +72,16 @@ def get_data():
         bills = query_table('public', 'processed_bills_20252026') # this is pulling a view, not a table
         return bills
     
+    @st.cache_data
+    def get_bill_events():
+        bill_events = query_table('public', 'upcoming_bill_events_20252026')
+        return bill_events
+    
     # Call the cached function to get the data
     bills = get_bills()
+    bill_events = get_bill_events()
     
-    return bills
+    return bills, bill_events
 
 ###############################################################################
 
@@ -101,7 +107,7 @@ def get_custom_bill_details(bill_id):
             "org_position": result[3],
             "priority_tier": result[4],
             "community_sponsor": result[5],
-            "coalition": result[6],
+            #"coalition": result[6],
             "letter_of_support": result[7]
         }
     
@@ -110,7 +116,7 @@ def get_custom_bill_details(bill_id):
 
 ###############################################################################
 
-def save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support):
+def save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support):
     '''
     Saves custom fields that a user enters on the bills details page to the bill_custom_details table in postgres
     '''
@@ -133,16 +139,15 @@ def save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, 
             # If it exists, update the record
             cursor.execute("""
                 UPDATE public.bill_custom_details
-                SET org_position = %s, priority_tier = %s, community_sponsor = %s,
-                    coalition = %s, letter_of_support = %s
+                SET org_position = %s, priority_tier = %s, community_sponsor = %s, letter_of_support = %s
                 WHERE bill_id = %s
-            """, (bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, bill_id))
+            """, (bill_number, org_position, priority_tier, community_sponsor, letter_of_support, bill_id))
     else:
             # If it doesn't exist, insert a new record
             cursor.execute("""
-                INSERT INTO public.bill_custom_details (bill_id, org_position, priority_tier, community_sponsor, coalition, letter_of_support)
+                INSERT INTO public.bill_custom_details (bill_id, org_position, priority_tier, community_sponsor, letter_of_support)
                 VALUES (%s, %s, %s, %s, %s, %s)
-            """, (bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support))
+            """, (bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support))
 
     conn.commit()
     conn.close()

--- a/app/db/upcoming_bill_events_view.sql
+++ b/app/db/upcoming_bill_events_view.sql
@@ -1,0 +1,30 @@
+-- Create upcoming bill events view that includes upcoming committee hearing date and referred committee columns.
+---- Schema: Public
+---- Inputs: ca_dev.bill_history
+---- Outputs: public.upcoming_bill_events_20252026
+
+DROP VIEW IF EXISTS upcoming_bill_events_20252026;
+
+CREATE VIEW upcoming_bill_events_20252026 AS
+SELECT 
+    bh.bill_id,
+    bh.bill_number,
+    bh.leg_session,
+    bh.event_text,
+
+    -- Extracts the upcoming committee hearing date, or 'None' if no match is found
+    COALESCE(
+        CASE 
+            WHEN bh.event_text ~ 'May be heard in committee' THEN 
+                TO_DATE((regexp_match(bh.event_text, '(\w+ \d{1,2})'))[1] || ' ' || EXTRACT(YEAR FROM CURRENT_DATE), 'Month DD YYYY')
+        END::TEXT, 
+        'None'
+    ) AS upcoming_comm_mtg,
+
+    -- Extracts only the committee name (text after "Com. on " and before next period ".")
+    COALESCE(
+        (SELECT (regexp_match(bh.event_text, 'Com\. on ([^\.]+)'))[1]),
+        'None'
+    ) AS referred_committee
+
+FROM bill_history_20252026 bh;

--- a/app/utils/aggrid_styler.py
+++ b/app/utils/aggrid_styler.py
@@ -44,7 +44,7 @@ def draw_bill_grid(
         )
     
     # Configure special settings for certain columns (batch)
-    builder.configure_columns(['full_text','leginfo_link','coauthors','bill_history','leg_session','bill_id','chamber'],hide=True) # hide these columns in the initial dataframe
+    builder.configure_columns(['full_text','leginfo_link','coauthors','bill_history','leg_session','bill_id','chamber','referred_committee'],hide=True) # hide these columns in the initial dataframe
     
     # Configure special settings for individual columns
     #builder.configure_column('checkbox', headerName='', checkboxSelection=True, width=50, pinned='left') # option to add a specific checkbox column
@@ -57,6 +57,8 @@ def draw_bill_grid(
     builder.configure_column('leginfo_link',headerName = 'Link')
     builder.configure_column('leg_session',headerName = 'Session')
     builder.configure_column('date_introduced',headerName = 'Date Introduced')#,filter='agDateColumnFilter') # text filter for now
+    builder.configure_column('upcoming_comm_mtg',headerName = 'Upcoming Committee Meeting')
+    builder.configure_column('referred_committee',headerName = 'Referred Committee')
     builder.configure_column('chamber',headerName = 'Chamber',filter='agSetColumnFilter')
     builder.configure_column('full_text',headerName = 'Bill Text')
     builder.configure_column('bill_history',headerName = 'Bill History')

--- a/app/utils/display_utils.py
+++ b/app/utils/display_utils.py
@@ -31,6 +31,8 @@ def display_bill_info_text(selected_rows):
     full_text = selected_rows['full_text'].iloc[0]
     bill_history = selected_rows['bill_history'].iloc[0]
     bill_topic = selected_rows['bill_topic'].iloc[0]
+    bill_event = selected_rows['upcoming_comm_mtg'].iloc[0]
+    committee = selected_rows['referred_committee'].iloc[0]
     
     # Display Bill Info Below the Table
     st.markdown('### Bill Details')
@@ -63,46 +65,64 @@ def display_bill_info_text(selected_rows):
 
             st.markdown('')
 
-            st.markdown('##### Author')
-            st.markdown(author)
+            st.markdown('##### Chamber')
+            st.markdown(chamber)
             
             st.markdown('')
 
             st.markdown('##### Status')
             st.markdown(status)
 
+            if bill_event is not None:
+                st.markdown('##### Upcoming Committee Meeting')
+                st.markdown(bill_event)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+
         with col2:
             st.markdown('')
         
         with col3:
-            st.markdown('##### Chamber')
-            st.markdown(chamber)
+            st.markdown('##### Author')
+            st.markdown(author)
 
             st.markdown('')
 
-            st.markdown('##### Co-author(s)')
-            st.markdown(coauthors)
+            st.markdown('##### Legislative Session')
+            st.markdown(leg_session)            
 
             st.markdown('')
 
             st.markdown('##### Date Introduced')
             st.markdown(date_introduced)
+
+            if committee is not None:
+                st.markdown('##### Referred Committee')
+                st.markdown(committee)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
         
         with col4:
             st.markdown('')
         
         with col5:
-            if bill_topic != 'Uncategorized':
-                st.markdown('##### Bill Topic')
-                st.markdown(bill_topic)
+            if coauthors is not None:
+                st.markdown('##### Co-author(s)')
+                st.markdown(coauthors)
             else:
                 st.markdown('#### ')
                 st.markdown('')
             
             st.markdown('')
 
-            st.markdown('##### Legislative Session')
-            st.markdown(leg_session)
+            if bill_topic != 'Uncategorized':
+                st.markdown('##### Bill Topic')
+                st.markdown(bill_topic)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
 
             st.markdown('')
 
@@ -120,7 +140,7 @@ def display_bill_info_text(selected_rows):
     st.markdown('#### Custom Bill Details')
     st.write('Use this section to enter custom details for this bill.')
     with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):
-        col1, col2, col3, col4, col5 = st.columns([2, 2, 2, 2, 2])
+        col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
 
         with col1:
             st.markdown('##### Org Position')
@@ -143,12 +163,12 @@ def display_bill_info_text(selected_rows):
             community_sponsor = st.text_input('Enter Community Sponsor', 
                                             value=custom_details['community_sponsor'] if custom_details else '')
 
-        with col4:
-            st.markdown('##### Coalition')
-            coalition = st.text_input('Enter Coalition', 
-                                    value=custom_details['coalition'] if custom_details else '')
+        #with col4:
+        #    st.markdown('##### Coalition')
+        #    coalition = st.text_input('Enter Coalition', 
+        #                            value=custom_details['coalition'] if custom_details else '')
 
-        with col5:
+        with col4:
             st.markdown('##### Letter of Support')
             letter_of_support = st.text_input('Link to Letter of Support', 
                                             value=custom_details['letter_of_support'] if custom_details else '')
@@ -159,7 +179,7 @@ def display_bill_info_text(selected_rows):
                                         type='secondary')
 
         if submitted:
-            save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support)
+            save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support)
             st.success("Custom details saved successfully!")
 
     # Add empty rows of space    
@@ -324,7 +344,7 @@ def display_dashboard_details(selected_rows):
     st.markdown('#### Custom Bill Details')
     st.write('Use this section to enter custom details for this bill.')
     with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):
-        col1, col2, col3, col4, col5 = st.columns([2, 2, 2, 2, 2])
+        col1, col2, col3, col4, col5 = st.columns([2, 2, 2, 2])
 
         with col1:
             st.markdown('##### Org Position')
@@ -347,12 +367,12 @@ def display_dashboard_details(selected_rows):
             community_sponsor = st.text_input('Enter Community Sponsor', 
                                             value=custom_details['community_sponsor'] if custom_details else '')
 
-        with col4:
-            st.markdown('##### Coalition')
-            coalition = st.text_input('Enter Coalition', 
-                                    value=custom_details['coalition'] if custom_details else '')
+        #with col4:
+        #    st.markdown('##### Coalition')
+        #    coalition = st.text_input('Enter Coalition', 
+        #                            value=custom_details['coalition'] if custom_details else '')
 
-        with col5:
+        with col4:
             st.markdown('##### Letter of Support')
             letter_of_support = st.text_input('Link to Letter of Support', 
                                             value=custom_details['letter_of_support'] if custom_details else '')
@@ -363,7 +383,7 @@ def display_dashboard_details(selected_rows):
                                         type='secondary')
 
         if submitted:
-            save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support)
+            save_custom_bill_details(bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support)
             st.success("Custom details saved successfully!")
 
     # Add empty rows of space    


### PR DESCRIPTION
- New view added to postgres db that creates two new columns for the bills table from bill history: `upcoming_comm_mtg` and `referred_committee`
- Upcoming committee meeting is shown by default in the main bills table
- Referred committee is shown only in bill details, if the value exists
- A start to #51, though more work probably necessary 

Other updates: 
- Resolved #31: Removed coalition custom field (though column still exists in postgres in case we want to turn it on later)
- Adjusted bill details function to make it so that certain values only appear if they are not None/have meaningful data (coauthors, bill topic, etc)
