### PR TITLE
Bill events calendar enhancements

### DIFF
--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -66,10 +66,7 @@ def load_bill_events():
 
 bill_events = load_bill_events()
 
-
-######################### ADD FILTER / SIDE BAR ###################################
-
-######################### ADD FILTER / SIDE BAR ###################################
+######################### ADD FILTERS / SIDE BAR ###################################
 
 # Define event classes based on type
 event_classes = {
@@ -77,6 +74,27 @@ event_classes = {
     "Senate": "senate",
     "Assembly": "assembly",
 }
+
+# Color-coding for the tags in the event type multi-select box
+st.markdown("""
+<style>
+span[data-baseweb="tag"]:has(span[title="Legislative"]) {
+  color: white;
+  background-color: #1f77b4;
+}
+
+span[data-baseweb="tag"]:has(span[title="Senate"]) {
+  color: white;
+  background-color: #ff7f0e;
+}
+
+span[data-baseweb="tag"]:has(span[title="Assembly"]) {
+  color: white;
+  background-color: #2ca02c;
+}
+</style>
+""", unsafe_allow_html=True)
+
 
 # Get unique bill numbers for the bill filter -- these are the bills that have events
 unique_bills = sorted(bill_events['bill_number'].unique())
@@ -132,7 +150,6 @@ if not bill_filter_active:
 elif bill_filter_active == True:
     # If bill filter IS active, then turn off filter
     # This effectively bypasses the event type filter
-    #selected_types = list(event_classes.keys())
     st.sidebar.markdown("### Filter by Event Type")
     st.sidebar.info("Event type filter is disabled when specific bills are selected.")
 

--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -21,13 +21,17 @@ from db.query import query_table
 # Show the page title and description
 # st.set_page_config(page_title='Legislation Tracker', layout='wide') # can add page_icon argument
 st.title('Calendar')
-st.write(
+st.markdown(
     '''
-    This page shows important dates and deadlines for the current legislative cycle.
+    This calendar displays overall legislative events and deadlines, as well as bill-specific events such as when a bill is scheduled to be discussed in a committee meeting or floor hearing.
+    
+    Use the filters on the left to search for a specific bill event or filter by event type.
     '''
 )
+st.markdown(" ")
+st.markdown(" ")
 
-############################ LOAD AND SET UP DATA #############################
+############################ LOAD DATA #############################
 
 # Load the data from a CSV. We're caching this so it doesn't reload every time the app
 # reruns (e.g. if the user interacts with the widgets).
@@ -62,8 +66,10 @@ def load_bill_events():
 
 bill_events = load_bill_events()
 
-# Convert data to JSON format (necessary for streamlit_calendar)
-calendar_events = []
+
+######################### ADD FILTER / SIDE BAR ###################################
+
+######################### ADD FILTER / SIDE BAR ###################################
 
 # Define event classes based on type
 event_classes = {
@@ -72,28 +78,141 @@ event_classes = {
     "Assembly": "assembly",
 }
 
-# Convert legislative events
-for _, row in leg_events.iterrows():
-    calendar_events.append({
-        'title': row.get('title', 'Legislative Event'),  # Default title if missing
-        'start': row['start'],
-        'end': row['end'],
-        'allDay': 'true' if row['allDay'] else 'false',  # All legislative events are all-day
-        'type': 'Legislative',
-        'className': event_classes.get('Legislative', '')  # Assign class -- corresponds to color coding from css file
-    })
+# Get unique bill numbers for the bill filter -- these are the bills that have events
+unique_bills = sorted(bill_events['bill_number'].unique())
 
-# Convert bill events
-for _, row in bill_events.iterrows():
-    event_type = row['chamber']
-    calendar_events.append({
-        'title': f"{row['bill_number']} - {row['event_text']}",  # Concatenate bill_number and event_text to create title
-        'start': row['bill_event'], #if pd.notna(row['bill_event']) and row['bill_event'] else None,  # Use bill_event or null
-        'end': row['bill_event'], #if pd.notna(row['bill_event']) and row['bill_event'] else None,  # Use bill_event or null
-        'allDay': 'true' if row['allDay'] else 'false',  # Making bill events all day for now until we can add specific event times
-        'type': event_type,
-        'className': event_classes.get(event_type, '')  # Assign class -- corresponds to color coding from css file
-    })
+# Add bill filter with search functionality
+st.sidebar.markdown("### Filter by Bill")
+
+# Initialize variables to handle both filtering scenarios
+selected_types = []
+bill_filter_active = False
+selected_bills_for_calendar = []
+
+# Option to select from dashboard bills
+show_dashboard_bills = st.sidebar.checkbox("Only show events for bills from My Dashboard")
+
+# Determine eligibility for dashboard bill checkbox
+if show_dashboard_bills:
+    if 'user_info' not in st.session_state:
+        st.sidebar.warning("User not authenticated. Login to see dashboard bills.")
+        selected_bills_for_calendar = []
+        bill_filter_active = False
+    elif 'dashboard_bills' not in st.session_state or st.session_state.dashboard_bills is None or len(st.session_state.dashboard_bills) == 0:
+        st.sidebar.info("No bills saved to your dashboard. Go to the Bills page to add bills to your dashboard.")
+        selected_bills_for_calendar = []
+        bill_filter_active = False
+    else:
+        # Use the bills directly from session state
+        dashboard_bills = st.session_state.dashboard_bills['bill_number'].unique().tolist()
+        selected_bills_for_calendar = dashboard_bills
+        bill_filter_active = True
+        #st.sidebar.success(f"Showing {len(selected_bills_for_calendar)} bills from dashboard")
+elif not show_dashboard_bills:
+    # If not eligible for dashboard bill checkbox, show a multiselect search widget for all bills that have events
+    unique_bills = sorted(bill_events['bill_number'].unique())
+    selected_bills_for_calendar = st.sidebar.multiselect(
+        "Select specific bills:",
+        options=unique_bills,
+        default=[],  # No default selection
+        help="Type to search for specific bill numbers. Only bills that have events will appear."
+    )
+    if len(selected_bills_for_calendar) > 0: 
+        bill_filter_active = True
+
+# If bill filter is not active (i.e. dashboard checkbox is not selected AND bill multiselect is empty), then event type filter is active:
+if not bill_filter_active:
+    st.sidebar.markdown("### Filter by Event Type")
+    # Multi-select filter with event types
+    selected_types = st.sidebar.multiselect(
+        "Select event type(s):",
+        options=list(event_classes.keys()),
+        default=list(event_classes.keys())  # Default: Show all
+    )
+elif bill_filter_active == True:
+    # If bill filter IS active, then turn off filter
+    # This effectively bypasses the event type filter
+    #selected_types = list(event_classes.keys())
+    st.sidebar.markdown("### Filter by Event Type")
+    st.sidebar.info("Event type filter is disabled when specific bills are selected.")
+
+######################### CONVERT DATA ###################################
+
+def filter_events(selected_types, selected_bills_for_calendar, bill_filter_active):
+    '''
+    Filters calendar events by bill and event type, and converts data to json format for rendering in streamlit calendar.
+    '''
+    # Initiate empty list of calendar events
+    calendar_events = []
+    
+    # If filtering by bills (either dashboard bills or individually selected bills)
+    if bill_filter_active:
+        
+        # Filter the bill_events DataFrame to only include selected bills
+        filtered_bill_events = bill_events[bill_events['bill_number'].isin(selected_bills_for_calendar)]
+        
+        # Add each filtered bill event to the calendar event list 
+        for _, row in filtered_bill_events.iterrows():
+            
+            # Convert to JSON
+            calendar_events.append({
+                'title': f"{row['bill_number']} - {row['event_text']}", # Concatenate bill_number and event_text to create title
+                'start': row['bill_event'], #if pd.notna(row['bill_event']) and row['bill_event'] else None,  # Use bill_event or null
+                'end': row['bill_event'],  #if pd.notna(row['bill_event']) and row['bill_event'] else None,  # Use bill_event or null
+                'allDay': 'true' if row['allDay'] else 'false', #  Making bill events all day for now until we can add specific event times
+                'type': 'Assembly' if row['chamber'] == 'Assembly' else 'Senate',
+                'className': 'assembly' if row['chamber'] == 'Assembly' else 'senate'  # Assign class -- corresponds to color coding from css file
+            })           
+        
+    # If filtering by event type, not bill
+    elif not bill_filter_active and selected_types:
+
+        # Add legislative events if selected
+        if "Legislative" in selected_types:
+          for _, row in leg_events.iterrows():
+              calendar_events.append({
+                      'title': row.get('title', 'Legislative Event'), # Default title if missing
+                      'start': row['start'],
+                      'end': row['end'],
+                      'allDay': 'true' if row['allDay'] else 'false', # All legislative events are all-day
+                      'type': 'Legislative',
+                      'className': event_classes.get('Legislative', '') # Assign class -- corresponds to color coding from css file
+                  })
+              
+        # Add Assembly bill events if selected
+        if "Assembly" in selected_types:
+            assembly_events = bill_events[bill_events['chamber'] == 'Assembly']
+            for _, row in assembly_events.iterrows():
+                calendar_events.append({
+                    'title': f"{row['bill_number']} - {row['event_text']}",
+                    'start': row['bill_event'],
+                    'end': row['bill_event'],
+                    'allDay': 'true' if row['allDay'] else 'false', #  Making bill events all day for now until we can add specific event times
+                    'type': 'Assembly',
+                    'className': event_classes.get('Assembly', '') # Assign class -- corresponds to color coding from css file
+                })
+
+        # Add Senate bill events if selected
+        if "Senate" in selected_types:
+            senate_events = bill_events[bill_events['chamber'] == 'Senate']
+            for _, row in senate_events.iterrows():
+                calendar_events.append({
+                    'title': f"{row['bill_number']} - {row['event_text']}",
+                    'start': row['bill_event'],
+                    'end': row['bill_event'],
+                    'allDay': 'true' if row['allDay'] else 'false', #  Making bill events all day for now until we can add specific event times
+                    'type': 'Senate',
+                    'className': event_classes.get('Senate', '') # Assign class -- corresponds to color coding from css file
+                })
+    
+    return calendar_events
+
+    
+# Get filtered events
+calendar_events = filter_events(selected_types, selected_bills_for_calendar, bill_filter_active)
+
+# Display a count of filtered events (optional, for debugging)
+st.sidebar.markdown(f"**Number of events shown**: {len(calendar_events)}")
 
 ################################## CSS ###################################
 
@@ -138,12 +257,16 @@ calendar_options = {
 }
 
 
+# Render the calendar with a key that depends on the selected filters
+# This ensures the calendar re-renders when filters change
+calendar_key = f"calendar_{'-'.join(sorted(selected_types))}"
+
 # Render the calendar
 calendar = calendar(
     events=calendar_events,
     options=calendar_options,
     custom_css=custom_css,
-    key='calendar', # Assign a widget key to prevent state loss
+    key=calendar_key, # Assign unique widget key to prevent state loss
     )
 
 

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -38,6 +38,10 @@ with col2:
 # Fetch the user's saved bills from the database
 db_bills = get_my_dashboard_bills(user_email)
 
+# Store in session state for use in other pages
+if 'dashboard_bills' not in st.session_state or st.session_state.dashboard_bills is None:
+    st.session_state.dashboard_bills = db_bills
+
 # Minor data processing to match bills table
 db_bills['date_introduced'] = pd.to_datetime(db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
 db_bills['bill_event'] = pd.to_datetime(db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy==2.0.30
 streamlit-google-auth==1.1.8
 paramiko==3.4.1
 python-dotenv==0.21.0
+ics==0.7.2

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -56,7 +56,7 @@ html, body, [class*="css"] {
 
 /* Make past events faded */
 .fc-event-past {
-    opacity: 0.8;
+    opacity: 0.5;
 }
 
 /* Event block */

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -86,3 +86,21 @@ html, body, [class*="css"] {
 .fc-day-today {
     background-color: #ffffcc !important;
 }
+
+/* Legislative Events */
+.fc-event.legislative {
+    background-color: #1f77b4 !important; /* Blue */
+    border-color: #1f77b4 !important;
+}
+
+/* Senate Events */
+.fc-event.senate {
+    background-color: #ff7f0e !important; /* Orange */
+    border-color: #ff7f0e !important;
+}
+
+/* Assembly Events */
+.fc-event.assembly {
+    background-color: #2ca02c !important; /* Green */
+    border-color: #2ca02c !important;
+}

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -255,4 +255,3 @@ def to_csv(df) -> bytes:
     output.seek(0)
     return output.getvalue()
 
-


### PR DESCRIPTION
- Added color coding for legislative, senate, and assembly calendar events (Resolves #61)
- Added filters to calendar page to filter by my dashboard bills, individual bills, and event type (Resolves #65)
- Color-coded the event type tags in the multi-select widget to correspond to the event type color coding
- Added button to download event data as .ics file for import to external calendar (google, ical, etc.) (Resolves #66)
- Fixed bug where past events on the calendar were not rendering as faded in color