### PR TITLE
removed persistent cookie functionality until it works properly

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ This is the main script of the Legislation Tracker. To run the app locally, run:
 
 import streamlit as st
 import datetime
-from utils.authentication import login_page, signup_page, logout, get_organization_by_id, get_logged_in_user, get_user
+from utils.authentication import login_page, signup_page, logout, get_organization_by_id
 
 
 # Page configuration
@@ -50,19 +50,20 @@ if "logged_out" in st.session_state and st.session_state.logged_out:
 
 # Main authentication flow remains largely the same
 if 'authenticated' not in st.session_state:
-    email = get_logged_in_user()
-    if email:
-        user = get_user(email)
-        if user:
-            st.session_state['authenticated'] = True
-            st.session_state['user_id'] = user[0]
-            st.session_state['user_name'] = user[1]
-            st.session_state['user_email'] = user[2]
-            st.session_state['org_id'] = user[4]
-            org = get_organization_by_id(user[4])
-            if org:
-                st.session_state['org_name'] = org[1]
-            st.rerun()
+    # Logic for checking if the user is logged in in order to keep them logged in across sessions via cookies -- TURNED OFF FOR NOW BC THIS IS STILL IN DEVELOPMENT!!
+    #email = get_logged_in_user()
+    #if email:
+    #    user = get_user(email)
+    #    if user:
+    #        st.session_state['authenticated'] = True
+    #        st.session_state['user_id'] = user[0]
+    #        st.session_state['user_name'] = user[1]
+    #        st.session_state['user_email'] = user[2]
+    #        st.session_state['org_id'] = user[4]
+    #        org = get_organization_by_id(user[4])
+    #        if org:
+    #            st.session_state['org_name'] = org[1]
+    #        st.rerun()
     
     if st.session_state.get('show_signup', False):
         signup_page()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,4 +9,5 @@ streamlit-google-auth==1.1.8
 paramiko==3.4.1
 python-dotenv==0.21.0
 ics==0.7.2
-streamlit-cookies-manager
+#streamlit-cookies-manager
+#git+https://github.com/dsherbini/streamlit-cookies-manager.git # using forkec version of streamlit-cookies-manager

--- a/app/utils/authentication.py
+++ b/app/utils/authentication.py
@@ -15,10 +15,12 @@ import re
 import os
 from db.config import config
 from typing import Optional, Tuple, List
-
-# Cookies functions for keeping users logged in
-from streamlit_cookies_manager import EncryptedCookieManager
 from datetime import datetime, timedelta
+
+'''
+# Cookies functions for keeping users logged in -- TURNED OFF BC THESE ARE STILL IN DEVELOPMENT!!
+from streamlit_cookies_manager import EncryptedCookieManager
+
 
 # Get secret key from environment variable or use a generated one
 def get_secret_key():
@@ -104,7 +106,8 @@ def clear_login_cookies():
     if "backup_user_email" in st.session_state:
         del st.session_state["backup_user_email"]
 
-
+'''
+        
 # Improved security and validation functions
 def validate_email(email: str) -> bool:
     """


### PR DESCRIPTION
Couldn't resolve error in streamlit-cookies-manager library due to outdated use of st.cache bc of old streamlit version, so decided to remove this functionality for now rather than have users see this warning when visiting the site. Need to find permanent solution to allow users to stay logged in across browser sessions. This was a challenge with Google Auth as well.