### PR TITLE
Org dashboard + other updates

### DIFF
--- a/app/archived_pages/archived_utils.py
+++ b/app/archived_pages/archived_utils.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+archived_utils.py
+Created on May 12, 2025
+
+Deprecated or outdated functions no longer in active use.
+
+"""
+
+import streamlit as st
+import pandas as pd
+from db.query import get_custom_bill_details, save_custom_bill_details, add_bill_to_dashboard, remove_bill_from_dashboard, add_bill_to_org_dashboard, remove_bill_from_org_dashboard, BILL_COLUMNS  
+
+##############################################################################
+
+# WARNING! THIS FUNCTION IS NOT UP TO DATE TO REFLECT LATEST CAPABILITIES OF DASHBOARD, ETC.
+# USE display_bill_info_text() !
+
+def display_bill_info_expander(selected_rows):
+    '''
+    Displays bill information in an expander when a row is selected in
+    an Ag Grid data frame.
+    
+    Note: expanders cannot exist within another expander.
+    '''
+    # Extract the values from the selected row
+    number = selected_rows['bill_number'].iloc[0]
+    name = selected_rows['bill_name'].iloc[0]
+    author = selected_rows['author'].iloc[0]
+    coauthors = selected_rows['coauthors'].iloc[0]
+    status = selected_rows['status'].iloc[0]
+    date = selected_rows['date_introduced'].iloc[0]
+    session = selected_rows['leg_session'].iloc[0]
+    chamber = selected_rows['chamber'].iloc[0]
+    link = selected_rows['leginfo_link'].iloc[0]
+    text = selected_rows['bill_text'].iloc[0]
+    history = selected_rows['bill_history'].iloc[0]
+      
+    with st.expander("View Bill Details", expanded=True):
+
+        # Containter with add to dashboard button in the top-right corner
+        with st.container(key='header_expander'):
+            col1, col2 = st.columns([7.5, 2.5])  # Adjust column widths as needed
+            with col1:
+                st.markdown('### Bill Details')
+            with col2:
+                if st.button('Add to Dashboard', use_container_width=True,):
+                    # Call the function to add the bill to the dashboard
+                    add_bill_to_dashboard(number, name, author, coauthors, status, date, chamber, link, text, history)
+        
+        # Add empty row of space  
+        st.write("")
+        
+        # Container for bill number and chamber
+        with st.container(key='number_chamber_expander'):
+            # Display columns with spacers
+            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+            with col1:
+                st.markdown('##### Bill Number')
+                st.markdown(number)
+            with col2:
+                st.markdown('##### Bill Name')
+                st.markdown(name)
+            with col3:
+                st.markdown('##### Chamber')
+                st.markdown(chamber)
+
+        # Add empty row of space    
+        st.write("")
+      
+        # Container for authors
+        with st.container(key='authors_expander'):
+            # Display columns with spacers
+            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+            with col1:
+                st.markdown('##### Author')
+                st.markdown(author)
+            with col2:
+                st.markdown('##### Co-author(s)')
+                st.markdown(coauthors)
+            with col3:
+                st.markdown('##### Legislative Session')
+                st.markdown(session)
+        
+        # Add empty row of space    
+        st.write("")
+  
+        # Container for status
+        with st.container(key='status_expander'):
+            # Display columns with spacers
+            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+            with col1:
+                st.markdown('##### Status')
+                st.markdown(status)
+            with col2:
+                st.markdown('##### Date Introduced')
+                st.markdown(date)
+            with col3:
+                st.markdown('##### Link to Bill')
+                st.link_button('leginfo.ca.gov', str(link))
+          
+        # Add empty row of space    
+        st.write("")
+            
+        # Scrollable text area for bill text
+        with st.container(key='bill_text_expander'):
+            st.markdown('##### Bill Excerpt')
+            st.text_area('For full bill text, refer to bill link.', text, height=300)
+          
+        # Scrollable text area for bill history
+        with st.container(key='bill_history_expander'):
+            st.markdown('##### Bill History')
+            st.text_area('For more details, refer to bill link.', history, height=300)
+
+###############################################################################
+
+# WARNING! THIS FUNCTION IS NOT UP TO DATE TO REFLECT LATEST CAPABILITIES OF DASHBOARD, ETC.
+# USE display_bill_info_text() !
+
+@st.dialog('Bill Details', width='large')
+def display_bill_info_dialog(selected_rows):
+    '''
+    Displays bill information in a dialog pop-up box when a row is selected in
+    an Ag Grid data frame.
+    
+    Note: this can be slow to load.
+    '''
+    # Extract the values from the selected row
+    number = selected_rows['bill_number'].iloc[0]
+    name = selected_rows['bill_name'].iloc[0]
+    author = selected_rows['author'].iloc[0]
+    coauthors = selected_rows['coauthors'].iloc[0]
+    status = selected_rows['status'].iloc[0]
+    date = selected_rows['date_introduced'].iloc[0]
+    session = selected_rows['leg_session'].iloc[0]
+    chamber = selected_rows['chamber'].iloc[0]
+    link = selected_rows['leginfo_link'].iloc[0]
+    text = selected_rows['bill_text'].iloc[0]
+    history = selected_rows['bill_history'].iloc[0]
+      
+    # Containter with add to dashboard button in the top-right corner
+    with st.container(key='header_dialog'):
+        col1, col2 = st.columns([7.5, 2.5])  # Adjust column widths as needed
+        with col1:
+            st.write("")
+        with col2:
+            if st.button('Add to Dashboard', use_container_width=True,):
+                # Call the function to add the bill to the dashboard
+                add_bill_to_dashboard(number, name, author, coauthors, status, date, chamber, link, text, history)
+    
+    # Add empty row of space  
+    st.write("")
+    
+    # Container for bill number and chamber
+    with st.container(key='number_chamber_dialog'):
+        # Display columns with spacers
+        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+        with col1:
+            st.markdown('##### Bill Number')
+            st.markdown(number)
+        with col2:
+            st.markdown('##### Bill Name')
+            st.markdown(name)
+        with col3:
+            st.markdown('##### Chamber')
+            st.markdown(chamber)
+
+    # Add empty row of space    
+    st.write("")
+  
+    # Container for authors
+    with st.container(key='authors_dialog'):
+        # Display columns with spacers
+        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+        with col1:
+            st.markdown('##### Author')
+            st.markdown(author)
+        with col2:
+            st.markdown('##### Co-author(s)')
+            st.markdown(coauthors)
+        with col3:
+            st.markdown('##### Legislative Session')
+            st.markdown(session)
+    
+    # Add empty row of space    
+    st.write("")
+
+    # Container for status
+    with st.container(key='status_dialog'):
+        # Display columns with spacers
+        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
+        with col1:
+            st.markdown('##### Status')
+            st.markdown(status)
+        with col2:
+            st.markdown('##### Date Introduced')
+            st.markdown(date)
+        with col3:
+            st.markdown('##### Link to Bill')
+            st.link_button('leginfo.ca.gov', str(link))
+      
+    # Add empty row of space    
+    st.write("")
+    
+    # Expander for bill text
+    with st.container(key='bill_text_dialog'):
+        st.markdown('##### Bill Excerpt')
+        expander = st.expander('See bill text')
+        expander.write(text)
+      
+    # Expander for bill history
+    with st.container(key='bill_history_dialog'):
+        st.markdown('##### Bill History')
+        expander = st.expander('See bill history')
+        expander.markdown(history)

--- a/app/bills.py
+++ b/app/bills.py
@@ -19,11 +19,14 @@ from utils.display_utils import display_bill_info_text
 
 # Page title and description
 st.title('Bills')
+
+current_session = '2025-2026'
+
 st.write(
-    '''
-    This page shows California assembly and senate bill information. 
+    f"""
+    This page shows California assembly and senate bill information for the {current_session} legislative session. 
     Please note that the page may take a few moments to load.
-    '''
+    """
 )
 
 ############################ LOAD AND PROCESS BILLS DATA #############################
@@ -40,13 +43,24 @@ bills['bill_history'] = bills['bill_history'].apply(format_bill_history) #Format
 # Initialize session state for selected bills
 if 'selected_bills' not in st.session_state:
     st.session_state.selected_bills = []
+
+# Initialize session state for theme if not set
+if 'theme' not in st.session_state:
+    st.session_state.theme = 'streamlit'  # Default theme
     
 # Create a two-column layout
-col1, col2 = st.columns([4, 1])
+col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
+    selected_theme = st.selectbox(
+        'Change grid theme:',
+        options=['streamlit', 'alpine', 'balham', 'material'],
+        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+    )
+    
+with col2:    
     st.markdown("")
 
-with col2:
+with col3:
     st.download_button(
             label='Download Data as CSV',
             data=to_csv(bills),
@@ -55,12 +69,25 @@ with col2:
             use_container_width=True
         )
 
+
+# Update session state if the user picks a new theme
+if selected_theme != st.session_state.theme:
+    st.session_state.theme = selected_theme
+
+# Use the persisted theme
+theme = st.session_state.theme 
+
+# Display count of total bills above the table
+total_bills = len(bills)
+st.markdown(f"#### Total bills: {total_bills:,}")
+
 # Display the aggrid table
-data = aggrid_styler.draw_bill_grid(bills)
+data = aggrid_styler.draw_bill_grid(bills, theme=theme)
     
 selected_rows = data.selected_rows
 
 if selected_rows is not None and len(selected_rows) != 0:
         display_bill_info_text(selected_rows)
+
 
 

--- a/app/db/dashboard_tables.sql
+++ b/app/db/dashboard_tables.sql
@@ -1,0 +1,23 @@
+-- dashboard_tables.sql
+-- Create dashboard tables
+
+-- Table: user_bill_dashboard -- this table stores bills that users add to their individual dashboards
+CREATE TABLE IF NOT EXISTS user_bill_dashboard (
+    user_bill_dashboard_id SERIAL PRIMARY KEY,
+    user_email TEXT,
+    added_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    bill_number TEXT,
+    openstates_bill_id TEXT,
+    org_id INT
+);
+
+
+-- Table: org_bill_dashboard -- this table stores bills that users add to their ORG dashboards
+CREATE TABLE IF NOT EXISTS org_bill_dashboard (
+    org_bill_dashboard_id SERIAL PRIMARY KEY,
+    user_email TEXT,
+    added_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    bill_number TEXT,
+    openstates_bill_id TEXT,
+    org_id INT
+);

--- a/app/db/query.py
+++ b/app/db/query.py
@@ -359,69 +359,197 @@ def remove_bill_from_org_dashboard(openstates_bill_id, bill_number):
 
 def get_custom_bill_details(openstates_bill_id):
     '''
-    Fetches custom bill details for a specific openstates_bill_id from the bill_custom_details table in postgres and adds to the bills details page
+    Fetches custom bill details for a specific openstates_bill_id from the bill_custom_details table in postgres and renders in the bill details page.
     '''
     # Load the database configuration
     db_config = config('postgres')
-    
     # Establish connection to the PostgreSQL server
     conn = psycopg2.connect(**db_config)
     print("Connected to the PostgreSQL database.")
     
-    # Query
-    cursor = conn.cursor()
+    # Create a cursor that returns rows as dictionaries
+    cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    
     cursor.execute("SELECT * FROM public.bill_custom_details WHERE openstates_bill_id = %s", (openstates_bill_id,))
     result = cursor.fetchone()
     conn.close()
     
     if result:
         return {
-            "org_position": result[3],
-            "priority_tier": result[4],
-            "community_sponsor": result[5],
-            #"coalition": result[6],
-            "letter_of_support": result[7]
+            "org_position": result["org_position"],
+            "priority_tier": result["priority_tier"],
+            "community_sponsor": result["community_sponsor"],
+            "coalition": result["coalition"],
+            "letter_of_support": result["letter_of_support"],
+            "assigned_to": result["assigned_to"],
+            "action_taken": result["action_taken"],
         }
+    else:
+        return None
     
+
+def get_custom_bill_details_with_timestamp(openstates_bill_id):
+    '''
+    Fetches custom bill details for a specific openstates_bill_id from the bill_custom_details table in postgres and renders in the bill details page, 
+    along with the timestamp of the last update and the user who made the changes.
+    '''
+    # Load the database configuration
+    db_config = config('postgres')
+    # Establish connection to the PostgreSQL server
+    conn = psycopg2.connect(**db_config)
+    print("Connected to the PostgreSQL database.")
+    
+    # Create a cursor that returns rows as dictionaries
+    cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    
+    cursor.execute("SELECT * FROM public.bill_custom_details WHERE openstates_bill_id = %s", (openstates_bill_id,))
+    result = cursor.fetchone()
+    conn.close()
+    
+    if result:
+        return {
+            "org_position": result["org_position"],
+            "priority_tier": result["priority_tier"],
+            "community_sponsor": result["community_sponsor"],
+            "coalition": result["coalition"],
+            "letter_of_support": result["letter_of_support"],
+            "assigned_to": result["assigned_to"],
+            "action_taken": result["action_taken"],
+            "last_updated_by": result["last_updated_by"],
+            "last_updated_org_id": result["last_updated_org_id"],
+            "last_updated_org_name": result["last_updated_org_name"],
+            "last_updated_on": result["last_updated_on"],
+            "last_updated_at": result["last_updated_on"],
+        }
     else:
         return None
 
 ###############################################################################
 
-def save_custom_bill_details(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support):
+def save_custom_bill_details(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, assigned_to, action_taken):
     '''
-    Saves custom fields that a user enters on the bills details page to the bill_custom_details table in postgres
+    Saves or updates custom bill details for a specific openstates_bill_id in the bill_custom_details table
     '''
     # Load the database configuration
     db_config = config('postgres')
-
-    # Ensure bill_id is an integer
-    #bill_id = int(bill_id)
     
     # Establish connection to the PostgreSQL server
     conn = psycopg2.connect(**db_config)
-    print("Connected to the PostgreSQL database.")
+    
+    # Create a cursor
     cursor = conn.cursor()
     
-    # Check if the record exists in database
-    cursor.execute("SELECT * FROM public.bill_custom_details WHERE openstates_bill_id = %s", (openstates_bill_id,))
-    existing_record = cursor.fetchone()
-
-    if existing_record:
-            # If it exists, update the record
-            cursor.execute("""
-                UPDATE public.bill_custom_details
-                SET org_position = %s, priority_tier = %s, community_sponsor = %s, letter_of_support = %s
-                WHERE openstates_bill_id = %s
-            """, (bill_number, org_position, priority_tier, community_sponsor, letter_of_support, openstates_bill_id))
+    # Check if a record already exists for this bill
+    cursor.execute("SELECT 1 FROM public.bill_custom_details WHERE openstates_bill_id = %s", (openstates_bill_id,))
+    exists = cursor.fetchone()
+    
+    if exists:
+        # Update existing record
+        cursor.execute("""
+            UPDATE public.bill_custom_details 
+            SET bill_number = %s,
+                org_position = %s,
+                priority_tier = %s,
+                community_sponsor = %s,
+                coalition = %s,      
+                letter_of_support = %s,
+                assigned_to = %s,
+                action_taken = %s
+            WHERE openstates_bill_id = %s
+            """, 
+            (bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, assigned_to, action_taken, openstates_bill_id)
+        )
     else:
-            # If it doesn't exist, insert a new record
-            cursor.execute("""
-                INSERT INTO public.bill_custom_details (openstates_bill_id, org_position, priority_tier, community_sponsor, letter_of_support)
-                VALUES (%s, %s, %s, %s, %s, %s)
-            """, (openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support))
-
+        # Insert new record
+        cursor.execute("""
+            INSERT INTO public.bill_custom_details 
+            (openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, assigned_to, action_taken)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """, 
+            (openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, assigned_to, action_taken)
+        )
+    
+    # Commit the transaction
     conn.commit()
     conn.close()
+    
+    print(f"Custom details for bill {bill_number} saved successfully.")
+
+
+##################################################################################
+
+def save_custom_bill_details_with_timestamp(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, 
+                      coalition, letter_of_support, assigned_to, action_taken, user_email=None, org_id=None, org_name=None):
+    '''
+    Saves or updates custom bill details for a specific openstates_bill_id in the bill_custom_details table and records who made the changes (user_email, org_id, org_name) and when (timestamp).
+    '''
+    # Load the database configuration
+    db_config = config('postgres')
+    
+    # Get current timestamp
+    import datetime
+    today = datetime.date.today()
+    current_timestamp = datetime.datetime.now()
+    
+    # Establish connection to the PostgreSQL server
+    conn = psycopg2.connect(**db_config)
+    
+    # Create a cursor
+    cursor = conn.cursor()
+    
+    # Check if a record already exists for this bill
+    cursor.execute("SELECT 1 FROM public.bill_custom_details WHERE openstates_bill_id = %s", (openstates_bill_id,))
+    exists = cursor.fetchone()
+    
+    try:
+        if exists:
+            # Update existing record
+            cursor.execute("""
+                UPDATE public.bill_custom_details
+                SET bill_number = %s,
+                    org_position = %s,
+                    priority_tier = %s,
+                    community_sponsor = %s,
+                    coalition = %s,
+                    letter_of_support = %s,
+                    assigned_to = %s,
+                    action_taken = %s,
+                    last_updated_by = %s,
+                    last_updated_org_id = %s,
+                    last_updated_org_name = %s,
+                    last_updated_on = %s,
+                    last_updated_at = %s
+                WHERE openstates_bill_id = %s
+            """,
+            (bill_number, org_position, priority_tier, community_sponsor, coalition, letter_of_support, 
+             assigned_to, action_taken, user_email, org_id, org_name, today, current_timestamp, openstates_bill_id)
+            )
+        else:
+            # Insert new record
+            cursor.execute("""
+                INSERT INTO public.bill_custom_details
+                (openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, 
+                 letter_of_support, assigned_to, action_taken, last_updated_by, last_updated_org_id, 
+                 last_updated_org_name, last_updated_on, last_updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, coalition, 
+             letter_of_support, assigned_to, action_taken, user_email, org_id, org_name, today, current_timestamp)
+            )
+        
+        # Commit the transaction
+        conn.commit()
+        print(f"Custom details for bill {bill_number} saved successfully by {user_email} from {org_name}.")
+        return True
+        
+    except Exception as e:
+        # Roll back the transaction in case of error
+        conn.rollback()
+        print(f"Error saving custom details for bill {bill_number}: {str(e)}")
+        raise e
+        
+    finally:
+        # Always close the connection
+        conn.close()
 
 

--- a/app/legislators.py
+++ b/app/legislators.py
@@ -44,11 +44,23 @@ def get_and_clean_leg_data():
 # Call function
 legislators = get_and_clean_leg_data()
 
-# Create two columns
-col1, col2 = st.columns([4.5, 1.25])  # Adjust column widths as needed
+# Initialize session state for theme if not set
+if 'theme' not in st.session_state:
+    st.session_state.theme = 'streamlit'  # Default theme
+    
+# Create a two-column layout
+col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
-    st.markdown("") # Blank space
-with col2: # Align download button to right side
+    selected_theme = st.selectbox(
+        'Change grid theme:',
+        options=['streamlit', 'alpine', 'balham', 'material'],
+        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+    )
+    
+with col2:    
+    st.markdown("")
+
+with col3:
     download_button = st.download_button(key='legislators_download',
                        label='Download Full Data as CSV',
                        data=to_csv(legislators),
@@ -57,8 +69,19 @@ with col2: # Align download button to right side
                        use_container_width=True
                         )
 
+# Update session state if the user picks a new theme
+if selected_theme != st.session_state.theme:
+    st.session_state.theme = selected_theme
+
+# Use the persisted theme
+theme = st.session_state.theme
+
+# Display count of total legislators above the table
+total_legislators = len(legislators)
+st.markdown(f"#### Total legislators: {total_legislators:,}")
+
 # Make the aggrid dataframe
-data = aggrid_styler.draw_leg_grid(legislators)
+data = aggrid_styler.draw_leg_grid(legislators, theme=theme)
 
 
 

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -28,6 +28,8 @@ if 'authenticated' not in st.session_state:
 #user_info = st.session_state['user_info']
 #user_email = st.session_state["user_info"].get("email")
 user_email = st.session_state['user_email']
+user_name = st.session_state['user_name']
+first_name = user_name.split()[0]  # Get the first name for a more personal greeting
 
 # Clear dashboard button
 col1, col2 = st.columns([4, 1])
@@ -52,14 +54,25 @@ st.session_state.dashboard_bills = db_bills
 db_bills['date_introduced'] = pd.to_datetime(db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
 db_bills['bill_event'] = pd.to_datetime(db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
 db_bills = get_bill_topics(db_bills, keyword_dict= keywords)  # Get bill topics
-#db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history_dashboard) #Format bill history
+db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
-# Buttom to download selected bills
-col1, col2 = st.columns([4, 1])
+# Initialize session state for theme if not set
+if 'theme' not in st.session_state:
+    st.session_state.theme = 'streamlit'  # Default theme
+    
+# Create a two-column layout
+col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
+    selected_theme = st.selectbox(
+        'Change grid theme:',
+        options=['streamlit', 'alpine', 'balham', 'material'],
+        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+    )
+    
+with col2:    
     st.markdown("")
 
-with col2:
+with col3:
     st.download_button(
             label='Download Data as CSV',
             data=to_csv(db_bills),
@@ -68,10 +81,17 @@ with col2:
             use_container_width=True
         )
 
+# Update session state if the user picks a new theme
+if selected_theme != st.session_state.theme:
+    st.session_state.theme = selected_theme
+
+# Use the persisted theme
+theme = st.session_state.theme 
 
 if not db_bills.empty:
-    st.write('Your saved bills:')
-    data = draw_bill_grid(db_bills)
+    total_db_bills = len(db_bills)
+    st.markdown(f"#### {first_name}'s saved bills: {total_db_bills} total bills")
+    data = draw_bill_grid(db_bills, theme=theme)
 
     # Display bill details for dashboard bills
     if 'selected_bills' not in st.session_state:

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -12,7 +12,7 @@ import streamlit as st
 import pandas as pd
 from utils.aggrid_styler import draw_bill_grid
 from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv
-from db.query import get_my_dashboard_bills
+from db.query import get_my_dashboard_bills, clear_all_my_dashboard_bills
 from utils.display_utils import display_dashboard_details, format_bill_history_dashboard
 
 
@@ -33,7 +33,9 @@ user_email = st.session_state['user_email']
 col1, col2 = st.columns([4, 1])
 with col2:
     if st.button('Clear Dashboard', use_container_width=True, type='primary'):
-        st.session_state.selected_bills = []  # Clear session state
+        clear_all_my_dashboard_bills(user_email)  # Actually remove the bills from the DB
+        st.session_state.selected_bills = []
+        st.session_state.dashboard_bills = pd.DataFrame()  # Clear in-memory DataFrame
         st.success('Dashboard cleared!')
 
 # Initialize session state for dashboard bills

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -21,7 +21,7 @@ if 'authenticated' not in st.session_state:
     st.error("User not authenticated. Please log in.")
     st.stop()  # Stop execution if the user is not authenticated
 
-# Access user info
+# Access user info from session state
 org_id = st.session_state.get('org_id')
 org_name = st.session_state['org_name']
 user_email = st.session_state['user_email']
@@ -50,13 +50,25 @@ st.session_state.org_dashboard_bills = org_db_bills
 org_db_bills['date_introduced'] = pd.to_datetime(org_db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
 org_db_bills['bill_event'] = pd.to_datetime(org_db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
 org_db_bills = get_bill_topics(org_db_bills, keyword_dict= keywords)  # Get bill topics
+org_db_bills['bill_history'] = org_db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
-# Buttom to download selected bills
-col1, col2 = st.columns([4, 1])
+# Initialize session state for theme if not set
+if 'theme' not in st.session_state:
+    st.session_state.theme = 'streamlit'  # Default theme
+    
+# Create a two-column layout
+col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
+    selected_theme = st.selectbox(
+        'Change grid theme:',
+        options=['streamlit', 'alpine', 'balham', 'material'],
+        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+    )
+    
+with col2:    
     st.markdown("")
 
-with col2:
+with col3:
     st.download_button(
             label='Download Data as CSV',
             data=to_csv(org_db_bills),
@@ -64,11 +76,19 @@ with col2:
             mime='text/csv',
             use_container_width=True
         )
+    
+# Update session state if the user picks a new theme
+if selected_theme != st.session_state.theme:
+    st.session_state.theme = selected_theme
+
+# Use the persisted theme
+theme = st.session_state.theme 
 
 # Draw the bill grid table
 if not org_db_bills.empty:
-    st.markdown(f"{org_name}'s saved bills:")
-    data = draw_bill_grid(org_db_bills)
+    total_org_db_bills = len(org_db_bills)
+    st.markdown(f"#### {org_name}'s saved bills: {total_org_db_bills} total bills")
+    data = draw_bill_grid(org_db_bills, theme=theme)
 
     # Display bill details for dashboard bills
     if 'selected_bills' not in st.session_state:

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -12,8 +12,8 @@ import streamlit as st
 import pandas as pd
 from utils.aggrid_styler import draw_bill_grid
 from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv
-from db.query import get_my_dashboard_bills
-from utils.display_utils import display_dashboard_details, format_bill_history_dashboard
+from db.query import get_org_dashboard_bills
+from utils.display_utils import display_org_dashboard_details, format_bill_history_dashboard
 
 
 # Ensure user info exists in the session (i.e. ensure the user is logged in)
@@ -29,6 +29,60 @@ user_email = st.session_state['user_email']
 # Page title
 st.title(f"{org_name}'s Dashboard")
 
-st.write("This page will be available only to users of a specific organization.")
+# Clear dashboard button -- DISABLED FOR NOW BC IT MIGHT GET MESSY HAVING THIS OPTION WITH MANY USERS SHARING ONE ORG DASHBOARD. but if we want to add it, the clear button on the my dashboard works.
+#col1, col2 = st.columns([4, 1])
+#with col2:
+#    if st.button('Clear Dashboard', use_container_width=True, type='primary'):
+#        st.session_state.selected_bills = []  # Clear session state
+#        st.success('Dashboard cleared!')
+
+# Initialize session state for org dashboard bills
+if 'org_dashboard_bills' not in st.session_state or st.session_state.org_dashboard_bills is None:
+    st.session_state.org_dashboard_bills = pd.DataFrame()  # Initialize as empty DataFrame
+
+# Fetch the user's org's saved bills from the database
+org_db_bills = get_org_dashboard_bills(org_id)
+
+# Update session state with user's org's dashboard bills
+st.session_state.org_dashboard_bills = org_db_bills
+
+# Minor data processing to match bills table
+org_db_bills['date_introduced'] = pd.to_datetime(org_db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
+org_db_bills['bill_event'] = pd.to_datetime(org_db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
+org_db_bills = get_bill_topics(org_db_bills, keyword_dict= keywords)  # Get bill topics
+
+# Buttom to download selected bills
+col1, col2 = st.columns([4, 1])
+with col1:
+    st.markdown("")
+
+with col2:
+    st.download_button(
+            label='Download Data as CSV',
+            data=to_csv(org_db_bills),
+            file_name='my_bills.csv',
+            mime='text/csv',
+            use_container_width=True
+        )
+
+# Draw the bill grid table
+if not org_db_bills.empty:
+    st.markdown(f"{org_name}'s saved bills:")
+    data = draw_bill_grid(org_db_bills)
+
+    # Display bill details for dashboard bills
+    if 'selected_bills' not in st.session_state:
+        st.session_state.selected_bills = []
+        
+    selected_rows = data.selected_rows
+
+    if selected_rows is not None and len(selected_rows) != 0:
+            display_org_dashboard_details(selected_rows)
+
+elif org_db_bills.empty:
+    st.write('No bills selected yet.')
+
+
+
 
 

--- a/app/utils/aggrid_styler.py
+++ b/app/utils/aggrid_styler.py
@@ -40,7 +40,7 @@ def draw_bill_grid(
         enableFilter=True,
         filter='agTextColumnFilter',
         floatingFilter=True, # floating filter: adds a row under the header row for the filter
-        #columnSize='sizeToFit'
+        columnSize='sizeToFit'
         )
     
     # Configure special settings for certain columns (batch)
@@ -83,7 +83,8 @@ def draw_bill_grid(
         wrap_text=wrap_text,
         theme=theme,
         key=key,
-        css=css
+        css=css,
+        #enable_enterprise_modules=False # this might get rid of the ag grid trial watermark but also disables the filter/pivot on the side of the table
     )
 
 
@@ -94,7 +95,7 @@ def draw_leg_grid(
         #selection='single', -- selection turned off for legislators table
         #use_checkbox=True, -- turned off for legislators table
         #header_checkbox = True, -- turned off for legislators table
-        fit_columns=True, # change to false to make all column width based on the variable
+        fit_columns=True, # change to True to make all column width based on the variable and fit the entire table to the window frame
         theme='streamlit', # options = streamlit, alpine, balham, material
         height: int = 600,
         wrap_text: bool = False,

--- a/app/utils/display_utils.py
+++ b/app/utils/display_utils.py
@@ -10,7 +10,7 @@ Functions for displaying bill details in different formats and on different page
 """
 import streamlit as st
 import pandas as pd
-from db.query import get_custom_bill_details, save_custom_bill_details, add_bill_to_dashboard, remove_bill_from_dashboard, add_bill_to_org_dashboard, remove_bill_from_org_dashboard, BILL_COLUMNS  
+from db.query import get_custom_bill_details, get_custom_bill_details_with_timestamp,save_custom_bill_details, save_custom_bill_details_with_timestamp, add_bill_to_dashboard, remove_bill_from_dashboard, add_bill_to_org_dashboard, remove_bill_from_org_dashboard, BILL_COLUMNS  
 
 def display_bill_info_text(selected_rows):
     '''
@@ -52,15 +52,15 @@ def display_bill_info_text(selected_rows):
         with col1:
             st.markdown(f'### {bill_number}')
         with col2:
-            # Add to MY DASHBOARD button
-            if st.button('Add to My Dashboard', use_container_width=True,type='primary'):
-                # Call the function to add the bill to the dashboard
-                add_bill_to_dashboard(openstates_bill_id, bill_number)
-
             # Add to ORG DASHBOARD button
             if st.button(f"Add to {org_name} Dashboard", use_container_width=True, type='primary'):
                 # Call the function to add the bill to the dashboard
                 add_bill_to_org_dashboard(openstates_bill_id, bill_number)
+
+            # Add to MY DASHBOARD button
+            if st.button('Add to My Dashboard', use_container_width=True,type='secondary'):
+                # Call the function to add the bill to the dashboard
+                add_bill_to_dashboard(openstates_bill_id, bill_number)
     
     # Add empty rows of space  
     st.write("")
@@ -147,66 +147,9 @@ def display_bill_info_text(selected_rows):
             st.markdown('##### Link to Bill')
             st.link_button('leginfo.ca.gov', str(leginfo_link))
 
-    # Add empty rows of space    
-    st.write("")
-    st.write("")
-
-    # Retrieve saved custom details
-    custom_details = get_custom_bill_details(openstates_bill_id)
-
-    # Form for custom user-entered fields
-    st.markdown('#### Custom Bill Details')
-    st.write('Use this section to enter custom details for this bill.')
-    with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):
-        col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
-
-        with col1:
-            st.markdown('##### Org Position')
-            org_position = st.selectbox('Select Org Position', 
-                                        ['','Needs Decision', 'Neutral/No Position', 'Support', 
-                                        'Support, if Amended', 'Oppose', 'Oppose, unless Amended'],
-                                        index=(['','Needs Decision', 'Neutral/No Position', 'Support', 
-                                                'Support, if Amended', 'Oppose', 'Oppose, unless Amended']
-                                            .index(custom_details['org_position']) if custom_details else 0))
-
-        with col2:
-            st.markdown('##### Priority Tier')
-            priority_tier = st.selectbox('Select Priority Tier', 
-                                        ['','Sponsored', 'Priority', 'Position', 'No Priority'],
-                                        index=(['','Sponsored', 'Priority', 'Position', 'No Priority']
-                                                .index(custom_details['priority_tier']) if custom_details else 0))
-
-        with col3:
-            st.markdown('##### Community Sponsor')
-            community_sponsor = st.text_input('Enter Community Sponsor', 
-                                            value=custom_details['community_sponsor'] if custom_details else '')
-
-        #with col4:
-        #    st.markdown('##### Coalition')
-        #    coalition = st.text_input('Enter Coalition', 
-        #                            value=custom_details['coalition'] if custom_details else '')
-
-        with col4:
-            st.markdown('##### Letter of Support')
-            letter_of_support = st.text_input('Link to Letter of Support', 
-                                            value=custom_details['letter_of_support'] if custom_details else '')
-
-        # Submit button
-        submitted = st.form_submit_button("Save Custom Bill Details", 
-                                        help='Click to save/update custom details for this bill', 
-                                        type='secondary')
-
-        if submitted:
-            save_custom_bill_details(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support)
-            st.success("Custom details saved successfully!")
-
-    # Add empty rows of space    
-    st.write("")
-    st.write("")
-
     # Expander for bill text
     with st.container(key='bill_text_text'):
-        st.markdown('##### Bill Excerpt')
+        st.markdown('#### Bill Excerpt')
         expander = st.expander('Click to view bill excerpt')
         expander.write(bill_text)
 
@@ -215,7 +158,7 @@ def display_bill_info_text(selected_rows):
 
     # Expander for bill history
     with st.container(key='bill_history_text'):
-        st.markdown('##### Bill History')
+        st.markdown('#### Bill History')
         expander = st.expander('Click to view bill history')
         expander.markdown(bill_history)
 
@@ -251,7 +194,7 @@ def format_bill_history_dashboard(bill_history):
 
 ###############################################################################
 
-def display_dashboard_details(selected_rows):
+def display_dashboard_details_with_custom_fields(selected_rows):
     '''
     Displays bill details on the MY DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
     '''
@@ -448,6 +391,225 @@ def display_dashboard_details(selected_rows):
         expander = st.expander('Click to view bill history')
         expander.markdown(bill_history)
 
+###################################################################################
+
+def display_dashboard_details(selected_rows):
+    '''
+    Displays bill details on the MY DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
+    '''
+    # Extract the values from the selected row
+    openstates_bill_id = selected_rows['openstates_bill_id'].iloc[0]
+    bill_number = selected_rows['bill_number'].iloc[0]
+    bill_name = selected_rows['bill_name'].iloc[0]
+    author = selected_rows['author'].iloc[0]
+    coauthors = selected_rows['coauthors'].iloc[0]
+    status = selected_rows['status'].iloc[0]
+    date_introduced = selected_rows['date_introduced'].iloc[0]
+    leg_session = selected_rows['leg_session'].iloc[0]
+    chamber = selected_rows['chamber'].iloc[0]
+    leginfo_link = selected_rows['leginfo_link'].iloc[0]
+    bill_text = selected_rows['bill_text'].iloc[0]
+    bill_history = selected_rows['bill_history'].iloc[0]
+    bill_topic = selected_rows['bill_topic'].iloc[0]
+    bill_event = selected_rows['bill_event'].iloc[0]
+    event_text = selected_rows['event_text'].iloc[0]
+    
+    # Display Bill Info Below the Table
+    st.markdown('### Bill Details')
+    st.divider()
+    
+    # Container with remove from dashboard button in the top-right corner
+    with st.container(key='title_button_container'):
+        col1, col2 = st.columns([7, 3])  # Adjust column widths as needed
+        with col1:
+            st.markdown(f'### {bill_number}')
+        with col2:
+            # If button is clicked: 
+            if st.button('Remove from My Dashboard', use_container_width=True, type='primary'):
+                # Call the function to remove the bill from the dashboard
+                remove_bill_from_dashboard(openstates_bill_id, bill_number)
+                
+                # Deselect the row and stop execution
+                st.session_state.selected_rows = None
+                st.rerun()  # Refresh the app to reflect the change
+
+    # Add empty rows of space  
+    st.write("")
+    st.write("")
+    
+    st.markdown('#### Main Bill Details')
+    # Container for bill number and chamber
+    with st.container(key='main_details_container_dashboard'):
+        # Display columns with spacers
+        col1, col2, col3, col4, col5 = st.columns([6, 1, 4, 1, 4])
+        with col1:
+            st.markdown('##### Bill Name')
+            st.markdown(bill_name)
+
+            st.markdown('')
+
+            st.markdown('##### Chamber')
+            st.markdown(chamber)
+            
+            st.markdown('')
+
+            st.markdown('##### Status')
+            st.markdown(status)
+
+            st.markdown('')
+
+            if bill_event is not None:
+                st.markdown('##### Bill Event Date')
+                st.markdown(bill_event)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+
+        with col2:
+            st.markdown('')
+        
+        with col3:
+            st.markdown('##### Author')
+            st.markdown(author)
+
+            st.markdown('')
+
+            st.markdown('##### Legislative Session')
+            st.markdown(leg_session)            
+
+            st.markdown('')
+
+            st.markdown('##### Date Introduced')
+            st.markdown(date_introduced)
+
+            st.markdown('')
+
+            if event_text is not None:
+                st.markdown('##### Bill Event Type/Location')
+                st.markdown('_Committee hearing, floor session, etc._')
+                st.markdown(event_text)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+        
+        with col4:
+            st.markdown('')
+        
+        with col5:
+            if coauthors is not None:
+                st.markdown('##### Co-author(s)')
+                st.markdown(coauthors)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+            
+            st.markdown('')
+
+            if bill_topic != 'Uncategorized':
+                st.markdown('##### Bill Topic')
+                st.markdown(bill_topic)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+
+            st.markdown('')
+
+            st.markdown('##### Link to Bill')
+            st.link_button('leginfo.ca.gov', str(leginfo_link))
+
+    # Add empty rows of space    
+    st.write("")
+    st.write("")
+
+    # Retrieve saved custom details
+    custom_details = get_custom_bill_details_with_timestamp(openstates_bill_id)
+
+    # Access user info from session state
+    org_id = st.session_state.get('org_id')
+    org_name = st.session_state['org_name']
+    user_email = st.session_state['user_email']
+
+    # Form for custom user-entered fields
+    st.markdown('#### Custom Bill Details')
+    st.markdown(f'This section contains information entered by members of your organization. <span title="These fields are only editable from your Organization Dashboard." style="cursor: help;">💬</span>', unsafe_allow_html=True)
+    
+    with st.container(key='custom_fields_container', border=True):
+        with st.container():
+            col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
+            with col1:
+                st.markdown('##### Org Position')
+                st.text(custom_details.get('org_position', ''))
+                
+            with col2:
+                st.markdown('##### Priority Tier')
+                st.text(custom_details.get('priority_tier', ''))
+                
+            with col3:
+                st.markdown('##### Community Sponsor')
+                st.text(custom_details.get('community_sponsor', ''))        
+            
+            with col4:
+                st.markdown('##### Coalition')
+                st.text(custom_details.get('coalition', ''))
+
+            # Add empty rows of space    
+            st.write("")
+            st.write("")
+        
+        # Second row with 4 columns
+        with st.container():
+            col5, col6, col7, col8 = st.columns([2, 2, 2, 2])
+            with col5:
+                st.markdown('##### Action Taken')
+                st.text(custom_details.get('action_taken', ''))    
+
+            with col6:
+                st.markdown('##### Assigned To')
+                st.text(custom_details.get('assigned_to', ''))
+
+            with col7:
+                st.markdown('##### Letter of Support')
+                letter_of_support = custom_details.get('letter_of_support', '')
+                if letter_of_support:
+                    st.link_button('Open Link', str(letter_of_support))
+                
+            with col8:
+                    st.markdown('')
+                    st.markdown('')
+                    st.markdown('')
+
+        # Add message below the form displaying who last saved the custom details
+        st.write("")
+        with st.container():
+            if custom_details:
+                # Get the user who saved the details, but remove .com/.us slug from email so it doesn't hyperlink the text
+                saved_by = custom_details.get('last_updated_by', 'Unknown')
+                who = saved_by.split('.')[0]
+
+                # Get date
+                when = custom_details.get('last_updated_on', 'Unknown')
+                when = when.strftime('%m-%d-%Y') # Format date to MM-DD-YYYY
+                st.markdown(f"*Custom details last saved by {who} on {when}.*")
+
+    # Add empty rows of space    
+    st.write("")
+    st.write("")
+
+    # Expander for bill text
+    with st.container(key='bill_text_text'):
+        st.markdown('#### Bill Excerpt')
+        expander = st.expander('Click to view bill excerpt')
+        expander.write(bill_text)
+
+    # Add empty rows of space    
+    st.write("")
+
+    # Expander for bill history
+    with st.container(key='bill_history_text'):
+        st.markdown('#### Bill History')
+        expander = st.expander('Click to view bill history')
+        expander.markdown(bill_history)
+
 ####################################################################################
 
 def display_org_dashboard_details(selected_rows):
@@ -579,66 +741,154 @@ def display_org_dashboard_details(selected_rows):
             st.markdown('##### Link to Bill')
             st.link_button('leginfo.ca.gov', str(leginfo_link))
 
-    # Add empty rows of space    
-    st.write("")
-    st.write("")
-
     # Retrieve saved custom details
-    custom_details = get_custom_bill_details(openstates_bill_id)
+    custom_details = get_custom_bill_details_with_timestamp(openstates_bill_id)
 
     # Form for custom user-entered fields
     st.markdown('#### Custom Bill Details')
-    st.write('Use this section to enter custom details for this bill.')
+    st.markdown('Use this section to enter custom details for this bill. <span title="These fields are also viewable on the My Dashboard page if you add this bill to your personal dashboard, but are only editable from your Organization Dashboard." style="cursor: help;">💬</span>', unsafe_allow_html=True)
+
+    # Access user info from session state
+    org_id = st.session_state.get('org_id')
+    org_name = st.session_state['org_name']
+    user_email = st.session_state['user_email']
+
     with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):
-        col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
+        # First row with 4 columns
+        with st.container():
+            col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
+            
+            with col1:
+                st.markdown('##### Org Position')
+                org_position_options = ['','Needs Decision', 'Neutral/No Position', 'Support',
+                                    'Support, if Amended', 'Oppose', 'Oppose, unless Amended']
+                
+                # Get the index
+                org_position_default = 0
+                if custom_details and 'org_position' in custom_details and custom_details['org_position'] in org_position_options:
+                    org_position_default = org_position_options.index(custom_details['org_position'])
+                    
+                org_position = st.selectbox('Select Org Position', 
+                                            org_position_options,
+                                            index=org_position_default)
+            
+            with col2:
+                st.markdown('##### Priority Tier')
+                priority_tier_options = ['','Sponsored', 'Priority', 'Position', 'No Priority']
+                
+                # Get the index
+                priority_tier_default = 0
+                if custom_details and 'priority_tier' in custom_details and custom_details['priority_tier'] in priority_tier_options:
+                    priority_tier_default = priority_tier_options.index(custom_details['priority_tier'])
+                    
+                priority_tier = st.selectbox('Select Priority Tier', 
+                                            priority_tier_options,
+                                            index=priority_tier_default)
+            
+            with col3:
+                st.markdown('##### Community Sponsor')
+                community_sponsor = st.text_input('Enter Community Sponsor',
+                                                value=custom_details.get('community_sponsor', '') if custom_details else '')
+            
+            with col4:
+                st.markdown('##### Coalition')
+                coalition = st.text_input('Enter Coalition',
+                                        value=custom_details.get('coalition', '') if custom_details else '')
 
-        with col1:
-            st.markdown('##### Org Position')
-            org_position = st.selectbox('Select Org Position', 
-                                        ['','Needs Decision', 'Neutral/No Position', 'Support', 
-                                        'Support, if Amended', 'Oppose', 'Oppose, unless Amended'],
-                                        index=(['','Needs Decision', 'Neutral/No Position', 'Support', 
-                                                'Support, if Amended', 'Oppose', 'Oppose, unless Amended']
-                                            .index(custom_details['org_position']) if custom_details else 0))
+        # Add empty rows of space    
+        st.write("")
+        st.write("")
+        
+        # Second row with 4 columns
+        with st.container():
+            col5, col6, col7, col8 = st.columns([2, 2, 2, 2])
+            
+            with col5:
+                st.markdown('##### Action Taken')
+                action_taken_options = ['','None', 'Letter of Support In Progress',
+                                    'Letter of Support Drafted', 'Letter of Support Submitted']
+                
+                # Get the index
+                action_taken_default = 0
+                if custom_details and 'action_taken' in custom_details and custom_details['action_taken'] in action_taken_options:
+                    action_taken_default = action_taken_options.index(custom_details['action_taken'])
+                    
+                action_taken = st.selectbox('Select Action Taken', 
+                                        action_taken_options,
+                                        index=action_taken_default)
+            
+            with col6:
+                st.markdown('##### Assigned To')
+                assigned_to = st.text_input('Enter Name',
+                                        value=custom_details.get('assigned_to', '') if custom_details else '')
+            
+            with col7:
+                st.markdown('##### Letter of Support')
+                letter_of_support = st.text_input('Enter link to letter of support',
+                                                value=custom_details.get('letter_of_support', '') if custom_details else '')
+            
+            with col8:
+                if letter_of_support:
+                    st.markdown('##### View Support Letter')
+                    st.markdown('Open link to (must be valid URL in previous field)')
+                    st.link_button('Open Link', str(letter_of_support))
+                else:
+                    st.markdown('')
+                    st.markdown('')
+                    st.markdown('')
+        
+        # Submit button - make sure it's properly within the form
+        submitted = st.form_submit_button(
+            label="Save Custom Bill Details",
+            help='Click to save/update custom details for this bill',
+            type='primary'
+        )
 
-        with col2:
-            st.markdown('##### Priority Tier')
-            priority_tier = st.selectbox('Select Priority Tier', 
-                                        ['','Sponsored', 'Priority', 'Position', 'No Priority'],
-                                        index=(['','Sponsored', 'Priority', 'Position', 'No Priority']
-                                                .index(custom_details['priority_tier']) if custom_details else 0))
+        # Add message below the form displaying who last saved the custom details
+        st.write("")
+        with st.container():
+            if custom_details:
+                # Get the user who saved the details, but remove .com/.us slug from email so it doesn't hyperlink the text
+                saved_by = custom_details.get('last_updated_by', 'Unknown')
+                who = saved_by.split('.')[0]
 
-        with col3:
-            st.markdown('##### Community Sponsor')
-            community_sponsor = st.text_input('Enter Community Sponsor', 
-                                            value=custom_details['community_sponsor'] if custom_details else '')
+                # Get date
+                when = custom_details.get('last_updated_on', 'Unknown')
+                when = when.strftime('%m-%d-%Y') # Format date to MM-DD-YYYY
 
-        #with col4:
-        #    st.markdown('##### Coalition')
-        #    coalition = st.text_input('Enter Coalition', 
-        #                            value=custom_details['coalition'] if custom_details else '')
+                # Display message
+                st.markdown(f"*Custom details last saved by {who} on {when}.*")
 
-        with col4:
-            st.markdown('##### Letter of Support')
-            letter_of_support = st.text_input('Link to Letter of Support', 
-                                            value=custom_details['letter_of_support'] if custom_details else '')
-
-        # Submit button
-        submitted = st.form_submit_button("Save Custom Bill Details", 
-                                        help='Click to save/update custom details for this bill', 
-                                        type='secondary')
-
-        if submitted:
-            save_custom_bill_details(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support)
-            st.success("Custom details saved successfully!")
-
+    # Handle form submission outside the form
+    if submitted:
+        try:
+            # Update function call if needed
+            save_custom_bill_details_with_timestamp(
+                openstates_bill_id, 
+                bill_number, 
+                org_position, 
+                priority_tier, 
+                community_sponsor,
+                coalition, 
+                letter_of_support, 
+                assigned_to, 
+                action_taken,
+                user_email,
+                org_id,
+                org_name
+            )
+            st.success(f"Custom details for bill {bill_number} saved successfully by {user_email} from {org_name}.")
+            
+        except Exception as e:
+            st.error(f"Error saving details: {str(e)}")
+    
     # Add empty rows of space    
     st.write("")
     st.write("")
 
     # Expander for bill text
     with st.container(key='bill_text_text'):
-        st.markdown('##### Bill Excerpt')
+        st.markdown('#### Bill Excerpt')
         expander = st.expander('Click to view bill excerpt')
         expander.write(bill_text)
 
@@ -647,214 +897,10 @@ def display_org_dashboard_details(selected_rows):
 
     # Expander for bill history
     with st.container(key='bill_history_text'):
-        st.markdown('##### Bill History')
+        st.markdown('#### Bill History')
         expander = st.expander('Click to view bill history')
         expander.markdown(bill_history)
 
 
-###############################################################################
 
 
-
-###############################################################################
-
-# WARNING! THIS FUNCTION IS NOT UP TO DATE TO REFLECT LATEST CAPABILITIES OF DASHBOARD, ETC.
-# USE display_bill_info_text() !
-
-def display_bill_info_expander(selected_rows):
-    '''
-    Displays bill information in an expander when a row is selected in
-    an Ag Grid data frame.
-    
-    Note: expanders cannot exist within another expander.
-    '''
-    # Extract the values from the selected row
-    number = selected_rows['bill_number'].iloc[0]
-    name = selected_rows['bill_name'].iloc[0]
-    author = selected_rows['author'].iloc[0]
-    coauthors = selected_rows['coauthors'].iloc[0]
-    status = selected_rows['status'].iloc[0]
-    date = selected_rows['date_introduced'].iloc[0]
-    session = selected_rows['leg_session'].iloc[0]
-    chamber = selected_rows['chamber'].iloc[0]
-    link = selected_rows['leginfo_link'].iloc[0]
-    text = selected_rows['bill_text'].iloc[0]
-    history = selected_rows['bill_history'].iloc[0]
-      
-    with st.expander("View Bill Details", expanded=True):
-
-        # Containter with add to dashboard button in the top-right corner
-        with st.container(key='header_expander'):
-            col1, col2 = st.columns([7.5, 2.5])  # Adjust column widths as needed
-            with col1:
-                st.markdown('### Bill Details')
-            with col2:
-                if st.button('Add to Dashboard', use_container_width=True,):
-                    # Call the function to add the bill to the dashboard
-                    add_bill_to_dashboard(number, name, author, coauthors, status, date, chamber, link, text, history)
-        
-        # Add empty row of space  
-        st.write("")
-        
-        # Container for bill number and chamber
-        with st.container(key='number_chamber_expander'):
-            # Display columns with spacers
-            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-            with col1:
-                st.markdown('##### Bill Number')
-                st.markdown(number)
-            with col2:
-                st.markdown('##### Bill Name')
-                st.markdown(name)
-            with col3:
-                st.markdown('##### Chamber')
-                st.markdown(chamber)
-
-        # Add empty row of space    
-        st.write("")
-      
-        # Container for authors
-        with st.container(key='authors_expander'):
-            # Display columns with spacers
-            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-            with col1:
-                st.markdown('##### Author')
-                st.markdown(author)
-            with col2:
-                st.markdown('##### Co-author(s)')
-                st.markdown(coauthors)
-            with col3:
-                st.markdown('##### Legislative Session')
-                st.markdown(session)
-        
-        # Add empty row of space    
-        st.write("")
-  
-        # Container for status
-        with st.container(key='status_expander'):
-            # Display columns with spacers
-            col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-            with col1:
-                st.markdown('##### Status')
-                st.markdown(status)
-            with col2:
-                st.markdown('##### Date Introduced')
-                st.markdown(date)
-            with col3:
-                st.markdown('##### Link to Bill')
-                st.link_button('leginfo.ca.gov', str(link))
-          
-        # Add empty row of space    
-        st.write("")
-            
-        # Scrollable text area for bill text
-        with st.container(key='bill_text_expander'):
-            st.markdown('##### Bill Excerpt')
-            st.text_area('For full bill text, refer to bill link.', text, height=300)
-          
-        # Scrollable text area for bill history
-        with st.container(key='bill_history_expander'):
-            st.markdown('##### Bill History')
-            st.text_area('For more details, refer to bill link.', history, height=300)
-
-###############################################################################
-
-# WARNING! THIS FUNCTION IS NOT UP TO DATE TO REFLECT LATEST CAPABILITIES OF DASHBOARD, ETC.
-# USE display_bill_info_text() !
-
-@st.dialog('Bill Details', width='large')
-def display_bill_info_dialog(selected_rows):
-    '''
-    Displays bill information in a dialog pop-up box when a row is selected in
-    an Ag Grid data frame.
-    
-    Note: this can be slow to load.
-    '''
-    # Extract the values from the selected row
-    number = selected_rows['bill_number'].iloc[0]
-    name = selected_rows['bill_name'].iloc[0]
-    author = selected_rows['author'].iloc[0]
-    coauthors = selected_rows['coauthors'].iloc[0]
-    status = selected_rows['status'].iloc[0]
-    date = selected_rows['date_introduced'].iloc[0]
-    session = selected_rows['leg_session'].iloc[0]
-    chamber = selected_rows['chamber'].iloc[0]
-    link = selected_rows['leginfo_link'].iloc[0]
-    text = selected_rows['bill_text'].iloc[0]
-    history = selected_rows['bill_history'].iloc[0]
-      
-    # Containter with add to dashboard button in the top-right corner
-    with st.container(key='header_dialog'):
-        col1, col2 = st.columns([7.5, 2.5])  # Adjust column widths as needed
-        with col1:
-            st.write("")
-        with col2:
-            if st.button('Add to Dashboard', use_container_width=True,):
-                # Call the function to add the bill to the dashboard
-                add_bill_to_dashboard(number, name, author, coauthors, status, date, chamber, link, text, history)
-    
-    # Add empty row of space  
-    st.write("")
-    
-    # Container for bill number and chamber
-    with st.container(key='number_chamber_dialog'):
-        # Display columns with spacers
-        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-        with col1:
-            st.markdown('##### Bill Number')
-            st.markdown(number)
-        with col2:
-            st.markdown('##### Bill Name')
-            st.markdown(name)
-        with col3:
-            st.markdown('##### Chamber')
-            st.markdown(chamber)
-
-    # Add empty row of space    
-    st.write("")
-  
-    # Container for authors
-    with st.container(key='authors_dialog'):
-        # Display columns with spacers
-        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-        with col1:
-            st.markdown('##### Author')
-            st.markdown(author)
-        with col2:
-            st.markdown('##### Co-author(s)')
-            st.markdown(coauthors)
-        with col3:
-            st.markdown('##### Legislative Session')
-            st.markdown(session)
-    
-    # Add empty row of space    
-    st.write("")
-
-    # Container for status
-    with st.container(key='status_dialog'):
-        # Display columns with spacers
-        col1, spacer1, col2, spacer2, col3 = st.columns([3, 0.5, 3, 0.5, 3])
-        with col1:
-            st.markdown('##### Status')
-            st.markdown(status)
-        with col2:
-            st.markdown('##### Date Introduced')
-            st.markdown(date)
-        with col3:
-            st.markdown('##### Link to Bill')
-            st.link_button('leginfo.ca.gov', str(link))
-      
-    # Add empty row of space    
-    st.write("")
-    
-    # Expander for bill text
-    with st.container(key='bill_text_dialog'):
-        st.markdown('##### Bill Excerpt')
-        expander = st.expander('See bill text')
-        expander.write(text)
-      
-    # Expander for bill history
-    with st.container(key='bill_history_dialog'):
-        st.markdown('##### Bill History')
-        expander = st.expander('See bill history')
-        expander.markdown(history)

--- a/app/utils/display_utils.py
+++ b/app/utils/display_utils.py
@@ -10,7 +10,7 @@ Functions for displaying bill details in different formats and on different page
 """
 import streamlit as st
 import pandas as pd
-from db.query import get_custom_bill_details, save_custom_bill_details, add_bill_to_dashboard, remove_bill_from_dashboard, BILL_COLUMNS  
+from db.query import get_custom_bill_details, save_custom_bill_details, add_bill_to_dashboard, remove_bill_from_dashboard, add_bill_to_org_dashboard, remove_bill_from_org_dashboard, BILL_COLUMNS  
 
 def display_bill_info_text(selected_rows):
     '''
@@ -37,6 +37,10 @@ def display_bill_info_text(selected_rows):
     bill_topic = selected_rows['bill_topic'].iloc[0]
     bill_event = selected_rows['bill_event'].iloc[0]
     event_text = selected_rows['event_text'].iloc[0]
+
+    # Get the org details from session state
+    org_id = st.session_state.get('org_id')
+    org_name = st.session_state['org_name']
     
     # Display Bill Info Below the Table
     st.markdown('### Bill Details')
@@ -48,9 +52,15 @@ def display_bill_info_text(selected_rows):
         with col1:
             st.markdown(f'### {bill_number}')
         with col2:
+            # Add to MY DASHBOARD button
             if st.button('Add to My Dashboard', use_container_width=True,type='primary'):
                 # Call the function to add the bill to the dashboard
                 add_bill_to_dashboard(openstates_bill_id, bill_number)
+
+            # Add to ORG DASHBOARD button
+            if st.button(f"Add to {org_name} Dashboard", use_container_width=True, type='primary'):
+                # Call the function to add the bill to the dashboard
+                add_bill_to_org_dashboard(openstates_bill_id, bill_number)
     
     # Add empty rows of space  
     st.write("")
@@ -243,7 +253,7 @@ def format_bill_history_dashboard(bill_history):
 
 def display_dashboard_details(selected_rows):
     '''
-    Displays bill details on the dashboard page when a row is selected; features a button to remove a bill from your dashboard.
+    Displays bill details on the MY DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
     '''
     # Extract the values from the selected row
     openstates_bill_id = selected_rows['openstates_bill_id'].iloc[0]
@@ -437,6 +447,213 @@ def display_dashboard_details(selected_rows):
         st.markdown('##### Bill History')
         expander = st.expander('Click to view bill history')
         expander.markdown(bill_history)
+
+####################################################################################
+
+def display_org_dashboard_details(selected_rows):
+    '''
+    Displays bill details on the ORG DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
+    '''
+    # Extract the values from the selected row
+    openstates_bill_id = selected_rows['openstates_bill_id'].iloc[0]
+    bill_number = selected_rows['bill_number'].iloc[0]
+    bill_name = selected_rows['bill_name'].iloc[0]
+    author = selected_rows['author'].iloc[0]
+    coauthors = selected_rows['coauthors'].iloc[0]
+    status = selected_rows['status'].iloc[0]
+    date_introduced = selected_rows['date_introduced'].iloc[0]
+    leg_session = selected_rows['leg_session'].iloc[0]
+    chamber = selected_rows['chamber'].iloc[0]
+    leginfo_link = selected_rows['leginfo_link'].iloc[0]
+    bill_text = selected_rows['bill_text'].iloc[0]
+    bill_history = selected_rows['bill_history'].iloc[0]
+    bill_topic = selected_rows['bill_topic'].iloc[0]
+    bill_event = selected_rows['bill_event'].iloc[0]
+    event_text = selected_rows['event_text'].iloc[0]
+    
+    # Get the org detaila from session state
+    org_id = st.session_state.get('org_id')
+    org_name = st.session_state['org_name']
+
+    # Display Bill Info Below the Table
+    st.markdown('### Bill Details')
+    st.divider()
+    
+    # Container with remove from dashboard button in the top-right corner
+    with st.container(key='title_button_container'):
+        col1, col2 = st.columns([7, 3])  # Adjust column widths as needed
+        with col1:
+            st.markdown(f'### {bill_number}')
+        with col2:
+            # If button is clicked: 
+            if st.button(f"Remove from {org_name} Dashboard", use_container_width=True, type='primary'):
+                # Call the function to remove the bill from the dashboard
+                remove_bill_from_org_dashboard(openstates_bill_id, bill_number)
+                
+                # Deselect the row and stop execution
+                st.session_state.selected_rows = None
+                st.rerun()  # Refresh the app to reflect the change
+
+    # Add empty rows of space  
+    st.write("")
+    st.write("")
+    
+    st.markdown('#### Main Bill Details')
+    st.write("")
+    # Container for bill number and chamber
+    with st.container(key='main_details_container_dashboard'):
+        # Display columns with spacers
+        col1, col2, col3, col4, col5 = st.columns([6, 1, 4, 1, 4])
+        with col1:
+            st.markdown('##### Bill Name')
+            st.markdown(bill_name)
+
+            st.markdown('')
+
+            st.markdown('##### Chamber')
+            st.markdown(chamber)
+            
+            st.markdown('')
+
+            st.markdown('##### Status')
+            st.markdown(status)
+
+            st.markdown('')
+
+            if bill_event is not None:
+                st.markdown('##### Bill Event Date')
+                st.markdown(bill_event)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+
+        with col2:
+            st.markdown('')
+        
+        with col3:
+            st.markdown('##### Author')
+            st.markdown(author)
+
+            st.markdown('')
+
+            st.markdown('##### Legislative Session')
+            st.markdown(leg_session)            
+
+            st.markdown('')
+
+            st.markdown('##### Date Introduced')
+            st.markdown(date_introduced)
+
+            st.markdown('')
+
+            if event_text is not None:
+                st.markdown('##### Bill Event Type/Location')
+                st.markdown('_Committee hearing, floor session, etc._')
+                st.markdown(event_text)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+        
+        with col4:
+            st.markdown('')
+        
+        with col5:
+            if coauthors is not None:
+                st.markdown('##### Co-author(s)')
+                st.markdown(coauthors)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+            
+            st.markdown('')
+
+            if bill_topic != 'Uncategorized':
+                st.markdown('##### Bill Topic')
+                st.markdown(bill_topic)
+            else:
+                st.markdown('#### ')
+                st.markdown('')
+
+            st.markdown('')
+
+            st.markdown('##### Link to Bill')
+            st.link_button('leginfo.ca.gov', str(leginfo_link))
+
+    # Add empty rows of space    
+    st.write("")
+    st.write("")
+
+    # Retrieve saved custom details
+    custom_details = get_custom_bill_details(openstates_bill_id)
+
+    # Form for custom user-entered fields
+    st.markdown('#### Custom Bill Details')
+    st.write('Use this section to enter custom details for this bill.')
+    with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):
+        col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
+
+        with col1:
+            st.markdown('##### Org Position')
+            org_position = st.selectbox('Select Org Position', 
+                                        ['','Needs Decision', 'Neutral/No Position', 'Support', 
+                                        'Support, if Amended', 'Oppose', 'Oppose, unless Amended'],
+                                        index=(['','Needs Decision', 'Neutral/No Position', 'Support', 
+                                                'Support, if Amended', 'Oppose', 'Oppose, unless Amended']
+                                            .index(custom_details['org_position']) if custom_details else 0))
+
+        with col2:
+            st.markdown('##### Priority Tier')
+            priority_tier = st.selectbox('Select Priority Tier', 
+                                        ['','Sponsored', 'Priority', 'Position', 'No Priority'],
+                                        index=(['','Sponsored', 'Priority', 'Position', 'No Priority']
+                                                .index(custom_details['priority_tier']) if custom_details else 0))
+
+        with col3:
+            st.markdown('##### Community Sponsor')
+            community_sponsor = st.text_input('Enter Community Sponsor', 
+                                            value=custom_details['community_sponsor'] if custom_details else '')
+
+        #with col4:
+        #    st.markdown('##### Coalition')
+        #    coalition = st.text_input('Enter Coalition', 
+        #                            value=custom_details['coalition'] if custom_details else '')
+
+        with col4:
+            st.markdown('##### Letter of Support')
+            letter_of_support = st.text_input('Link to Letter of Support', 
+                                            value=custom_details['letter_of_support'] if custom_details else '')
+
+        # Submit button
+        submitted = st.form_submit_button("Save Custom Bill Details", 
+                                        help='Click to save/update custom details for this bill', 
+                                        type='secondary')
+
+        if submitted:
+            save_custom_bill_details(openstates_bill_id, bill_number, org_position, priority_tier, community_sponsor, letter_of_support)
+            st.success("Custom details saved successfully!")
+
+    # Add empty rows of space    
+    st.write("")
+    st.write("")
+
+    # Expander for bill text
+    with st.container(key='bill_text_text'):
+        st.markdown('##### Bill Excerpt')
+        expander = st.expander('Click to view bill excerpt')
+        expander.write(bill_text)
+
+    # Add empty rows of space    
+    st.write("")
+
+    # Expander for bill history
+    with st.container(key='bill_history_text'):
+        st.markdown('##### Bill History')
+        expander = st.expander('Click to view bill history')
+        expander.markdown(bill_history)
+
+
+###############################################################################
+
 
 
 ###############################################################################


### PR DESCRIPTION
**Dashboard updates**
- Created an org dashboard page (closed #86)
- Custom details are now editable only on the org dashboard page
- Custom details are viewable on the My Dashboard page
- Custom details are no longer viewable on the Bills page
- Clear dashboard button only on the My Dashboard page (in order to limit accidentally clearing an org dashboard)
- Added "last updated by" message to the Org Dashboard page
- Updated functions for getting & saving custom bill details from app to db (and vice versa)
- Button now appears linking out to letter of support if there is a valid URL populated in the letter of support custom field (closed #32)

**Cosmetic updates**
- Option to change Ag Grid theme for tables on each page
- Count of bills above table on each page

**Calendar updates**
- Filter for Org Dashboard bills now available in sidebar (though this probably needs refining)