### PR TITLE
fixed error in custom bill details + grid theme option

### DIFF
--- a/app/bills.py
+++ b/app/bills.py
@@ -44,38 +44,47 @@ bills['bill_history'] = bills['bill_history'].apply(format_bill_history) #Format
 if 'selected_bills' not in st.session_state:
     st.session_state.selected_bills = []
 
+# Mapping between user-friendly labels and internal theme values
+theme_options = {
+    'narrow': 'streamlit',
+    'wide': 'alpine'
+}
+
 # Initialize session state for theme if not set
 if 'theme' not in st.session_state:
     st.session_state.theme = 'streamlit'  # Default theme
-    
+
+# Reverse mapping to get the label from the internal value
+label_from_theme = {v: k for k, v in theme_options.items()}
+
 # Create a two-column layout
 col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
-    selected_theme = st.selectbox(
+    selected_label = st.selectbox(
         'Change grid theme:',
-        options=['streamlit', 'alpine', 'balham', 'material'],
-        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+        options=list(theme_options.keys()),
+        index=list(theme_options.keys()).index(label_from_theme[st.session_state.theme])
     )
-    
+
 with col2:    
     st.markdown("")
 
 with col3:
     st.download_button(
-            label='Download Data as CSV',
-            data=to_csv(bills),
-            file_name='selected_bills.csv',
-            mime='text/csv',
-            use_container_width=True
-        )
-
+        label='Download Data as CSV',
+        data=to_csv(bills),
+        file_name='selected_bills.csv',
+        mime='text/csv',
+        use_container_width=True
+    )
 
 # Update session state if the user picks a new theme
+selected_theme = theme_options[selected_label]
 if selected_theme != st.session_state.theme:
     st.session_state.theme = selected_theme
 
 # Use the persisted theme
-theme = st.session_state.theme 
+theme = st.session_state.theme
 
 # Display count of total bills above the table
 total_bills = len(bills)

--- a/app/legislators.py
+++ b/app/legislators.py
@@ -44,17 +44,26 @@ def get_and_clean_leg_data():
 # Call function
 legislators = get_and_clean_leg_data()
 
+# Mapping between user-friendly labels and internal theme values
+theme_options = {
+    'narrow': 'streamlit',
+    'wide': 'alpine'
+}
+
 # Initialize session state for theme if not set
 if 'theme' not in st.session_state:
     st.session_state.theme = 'streamlit'  # Default theme
-    
+
+# Reverse mapping to get the label from the internal value
+label_from_theme = {v: k for k, v in theme_options.items()}
+
 # Create a two-column layout
 col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
-    selected_theme = st.selectbox(
+    selected_label = st.selectbox(
         'Change grid theme:',
-        options=['streamlit', 'alpine', 'balham', 'material'],
-        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+        options=list(theme_options.keys()),
+        index=list(theme_options.keys()).index(label_from_theme[st.session_state.theme])
     )
     
 with col2:    
@@ -70,6 +79,7 @@ with col3:
                         )
 
 # Update session state if the user picks a new theme
+selected_theme = theme_options[selected_label]
 if selected_theme != st.session_state.theme:
     st.session_state.theme = selected_theme
 

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -56,17 +56,26 @@ db_bills['bill_event'] = pd.to_datetime(db_bills['bill_event']).dt.strftime('%Y-
 db_bills = get_bill_topics(db_bills, keyword_dict= keywords)  # Get bill topics
 db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
+# Mapping between user-friendly labels and internal theme values
+theme_options = {
+    'narrow': 'streamlit',
+    'wide': 'alpine'
+}
+
 # Initialize session state for theme if not set
 if 'theme' not in st.session_state:
     st.session_state.theme = 'streamlit'  # Default theme
-    
+
+# Reverse mapping to get the label from the internal value
+label_from_theme = {v: k for k, v in theme_options.items()}
+
 # Create a two-column layout
 col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
-    selected_theme = st.selectbox(
+    selected_label = st.selectbox(
         'Change grid theme:',
-        options=['streamlit', 'alpine', 'balham', 'material'],
-        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+        options=list(theme_options.keys()),
+        index=list(theme_options.keys()).index(label_from_theme[st.session_state.theme])
     )
     
 with col2:    
@@ -82,11 +91,12 @@ with col3:
         )
 
 # Update session state if the user picks a new theme
+selected_theme = theme_options[selected_label]
 if selected_theme != st.session_state.theme:
     st.session_state.theme = selected_theme
 
 # Use the persisted theme
-theme = st.session_state.theme 
+theme = st.session_state.theme
 
 if not db_bills.empty:
     total_db_bills = len(db_bills)

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -52,17 +52,26 @@ org_db_bills['bill_event'] = pd.to_datetime(org_db_bills['bill_event']).dt.strft
 org_db_bills = get_bill_topics(org_db_bills, keyword_dict= keywords)  # Get bill topics
 org_db_bills['bill_history'] = org_db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
+# Mapping between user-friendly labels and internal theme values
+theme_options = {
+    'narrow': 'streamlit',
+    'wide': 'alpine'
+}
+
 # Initialize session state for theme if not set
 if 'theme' not in st.session_state:
     st.session_state.theme = 'streamlit'  # Default theme
-    
+
+# Reverse mapping to get the label from the internal value
+label_from_theme = {v: k for k, v in theme_options.items()}
+
 # Create a two-column layout
 col1, col2, col3 = st.columns([1, 7, 2])
 with col1:
-    selected_theme = st.selectbox(
+    selected_label = st.selectbox(
         'Change grid theme:',
-        options=['streamlit', 'alpine', 'balham', 'material'],
-        index=['streamlit', 'alpine', 'balham', 'material'].index(st.session_state.theme)
+        options=list(theme_options.keys()),
+        index=list(theme_options.keys()).index(label_from_theme[st.session_state.theme])
     )
     
 with col2:    
@@ -78,11 +87,12 @@ with col3:
         )
     
 # Update session state if the user picks a new theme
+selected_theme = theme_options[selected_label]
 if selected_theme != st.session_state.theme:
     st.session_state.theme = selected_theme
 
 # Use the persisted theme
-theme = st.session_state.theme 
+theme = st.session_state.theme
 
 # Draw the bill grid table
 if not org_db_bills.empty:

--- a/app/utils/display_utils.py
+++ b/app/utils/display_utils.py
@@ -538,19 +538,19 @@ def display_dashboard_details(selected_rows):
             col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
             with col1:
                 st.markdown('##### Org Position')
-                st.text(custom_details.get('org_position', ''))
+                st.text(custom_details.get('org_position', '') if custom_details else '')
                 
             with col2:
                 st.markdown('##### Priority Tier')
-                st.text(custom_details.get('priority_tier', ''))
+                st.text(custom_details.get('priority_tier', '') if custom_details else '')
                 
             with col3:
                 st.markdown('##### Community Sponsor')
-                st.text(custom_details.get('community_sponsor', ''))        
+                st.text(custom_details.get('community_sponsor', '') if custom_details else '')      
             
             with col4:
                 st.markdown('##### Coalition')
-                st.text(custom_details.get('coalition', ''))
+                st.text(custom_details.get('coalition', '') if custom_details else '')
 
             # Add empty rows of space    
             st.write("")
@@ -561,15 +561,15 @@ def display_dashboard_details(selected_rows):
             col5, col6, col7, col8 = st.columns([2, 2, 2, 2])
             with col5:
                 st.markdown('##### Action Taken')
-                st.text(custom_details.get('action_taken', ''))    
+                st.text(custom_details.get('action_taken', '') if custom_details else '')
 
             with col6:
                 st.markdown('##### Assigned To')
-                st.text(custom_details.get('assigned_to', ''))
+                st.text(custom_details.get('assigned_to', '') if custom_details else '')
 
             with col7:
                 st.markdown('##### Letter of Support')
-                letter_of_support = custom_details.get('letter_of_support', '')
+                letter_of_support = custom_details.get('letter_of_support', '') if custom_details else ''
                 if letter_of_support:
                     st.link_button('Open Link', str(letter_of_support))
                 


### PR DESCRIPTION
- Two grid option themes were not rendering due to not having Ag Grid enterprise account; removed these options
- Custom bill details were causing error if they were empty and bill was added to dashboard; resolved this error