### PR TITLE
Bill topic, bills table caching, date column filter

### DIFF
--- a/app/bills.py
+++ b/app/bills.py
@@ -37,7 +37,6 @@ def load_bills_table():
     bills = get_data()
 
     # Minor data processing
-
     # Convert to datetime (without formatting yet)
     bills['date_introduced'] = pd.to_datetime(bills['date_introduced'], errors='coerce')
     bills['bill_event'] = pd.to_datetime(bills['bill_event'], errors='coerce')
@@ -55,10 +54,11 @@ def load_bills_table():
 
     return bills
 
-# Initialize session state for bills if not set
+# Initialize session state for bills and load bills if not set
 if 'bills' not in st.session_state:
      st.session_state.bills = load_bills_table()
 
+# Assign bills variable to session state bills for future access / to enable caching
 bills = st.session_state.bills
 
 # Initialize session state for selected bills

--- a/app/bills.py
+++ b/app/bills.py
@@ -14,7 +14,7 @@ import streamlit as st
 import pandas as pd
 from db.query import get_data
 from utils import aggrid_styler
-from utils.utils import get_bill_topics, to_csv, keywords, format_bill_history
+from utils.utils import get_bill_topics, to_csv, keywords, format_bill_history, get_bill_topics_multiple
 from utils.display_utils import display_bill_info_text
 
 # Page title and description
@@ -31,14 +31,35 @@ st.write(
 
 ############################ LOAD AND PROCESS BILLS DATA #############################
 
-# Get data
-bills = get_data()
+@st.cache_data(show_spinner="Loading bills data...",ttl=60 * 60 * 11.5)
+def load_bills_table():
+    # Get data
+    bills = get_data()
 
-# Minor data processing 
-bills['date_introduced'] = pd.to_datetime(bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestamp from date introduced
-bills['bill_event'] = pd.to_datetime(bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
-bills = get_bill_topics(bills, keyword_dict= keywords)  # Get bill topics
-bills['bill_history'] = bills['bill_history'].apply(format_bill_history) #Format bill history
+    # Minor data processing
+
+    # Convert to datetime (without formatting yet)
+    bills['date_introduced'] = pd.to_datetime(bills['date_introduced'], errors='coerce')
+    bills['bill_event'] = pd.to_datetime(bills['bill_event'], errors='coerce')
+
+    # Sort bills table by most recent date_introduced
+    bills = bills.sort_values(by='date_introduced', ascending=False)
+
+    # Now remove timestamp from date_introduced and bill_event (for formatting purposes in other display areas)
+    bills['date_introduced'] = pd.to_datetime(bills['date_introduced']).dt.strftime('%m-%d-%Y') # Remove timestamp from date introduced
+    bills['bill_event'] = pd.to_datetime(bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
+
+    # Get bill topic and format bill history
+    bills = get_bill_topics_multiple(bills, keyword_dict= keywords)  # Get bill topics
+    bills['bill_history'] = bills['bill_history'].apply(format_bill_history) #Format bill history
+
+    return bills
+
+# Initialize session state for bills if not set
+if 'bills' not in st.session_state:
+     st.session_state.bills = load_bills_table()
+
+bills = st.session_state.bills
 
 # Initialize session state for selected bills
 if 'selected_bills' not in st.session_state:

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -11,7 +11,7 @@ Page to add bills to user's private dashboard
 import streamlit as st
 import pandas as pd
 from utils.aggrid_styler import draw_bill_grid
-from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv
+from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv, get_bill_topics_multiple
 from db.query import get_my_dashboard_bills, clear_all_my_dashboard_bills
 from utils.display_utils import display_dashboard_details, format_bill_history_dashboard
 
@@ -53,7 +53,7 @@ st.session_state.dashboard_bills = db_bills
 # Minor data processing to match bills table
 db_bills['date_introduced'] = pd.to_datetime(db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
 db_bills['bill_event'] = pd.to_datetime(db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
-db_bills = get_bill_topics(db_bills, keyword_dict= keywords)  # Get bill topics
+db_bills = get_bill_topics_multiple(db_bills, keyword_dict= keywords)  # Get bill topics
 db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
 # Mapping between user-friendly labels and internal theme values

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -11,7 +11,7 @@ Page to add bills to an org's private dashboard
 import streamlit as st
 import pandas as pd
 from utils.aggrid_styler import draw_bill_grid
-from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv
+from utils.utils import format_bill_history, get_bill_topics, keywords, to_csv, get_bill_topics_multiple
 from db.query import get_org_dashboard_bills
 from utils.display_utils import display_org_dashboard_details, format_bill_history_dashboard
 
@@ -49,7 +49,7 @@ st.session_state.org_dashboard_bills = org_db_bills
 # Minor data processing to match bills table
 org_db_bills['date_introduced'] = pd.to_datetime(org_db_bills['date_introduced']).dt.strftime('%Y-%m-%d') # Remove timestampe from date introduced
 org_db_bills['bill_event'] = pd.to_datetime(org_db_bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
-org_db_bills = get_bill_topics(org_db_bills, keyword_dict= keywords)  # Get bill topics
+org_db_bills = get_bill_topics_multiple(org_db_bills, keyword_dict= keywords)  # Get bill topics
 org_db_bills['bill_history'] = org_db_bills['bill_history'].apply(format_bill_history) #Format bill history
 
 # Mapping between user-friendly labels and internal theme values

--- a/app/utils/aggrid_styler.py
+++ b/app/utils/aggrid_styler.py
@@ -56,12 +56,12 @@ def draw_bill_grid(
     builder.configure_column('status',headerName = 'Status')
     builder.configure_column('leginfo_link',headerName = 'Link')
     builder.configure_column('leg_session',headerName = 'Session')
-    builder.configure_column('date_introduced',headerName = 'Date Introduced')#,filter='agDateColumnFilter') # text filter for now
+    builder.configure_column('date_introduced',headerName = 'Date Introduced',type=["dateColumnFilter", "customDateTimeFormat"],custom_format_string="dd-MM-yyyy",sortable=True) # have to add special arguments to enable date type filter and remove timestamp
     builder.configure_column('chamber',headerName = 'Chamber',filter='agSetColumnFilter')
     builder.configure_column('bill_text',headerName = 'Bill Text')
     builder.configure_column('bill_history',headerName = 'Bill History')
     builder.configure_column('bill_topic',headerName = 'Bill Topic', filter='agSetColumnFilter')
-    builder.configure_column('bill_event',headerName = 'Bill Event')
+    builder.configure_column('bill_event',headerName = 'Bill Event',type=["dateColumnFilter", "customDateTimeFormat"],custom_format_string="dd-MM-yyyy",sortable=True) # have to add special arguments to enable date type filter and remove timestamp
     builder.configure_column('event_text',headerName = 'Event Details')
     
     

--- a/app/utils/display_utils.py
+++ b/app/utils/display_utils.py
@@ -135,7 +135,7 @@ def display_bill_info_text(selected_rows):
             
             st.markdown('')
 
-            if bill_topic != 'Uncategorized':
+            if bill_topic:
                 st.markdown('##### Bill Topic')
                 st.markdown(bill_topic)
             else:
@@ -307,7 +307,7 @@ def display_dashboard_details_with_custom_fields(selected_rows):
             
             st.markdown('')
 
-            if bill_topic != 'Uncategorized':
+            if bill_topic:
                 st.markdown('##### Bill Topic')
                 st.markdown(bill_topic)
             else:
@@ -505,7 +505,7 @@ def display_dashboard_details(selected_rows):
             
             st.markdown('')
 
-            if bill_topic != 'Uncategorized':
+            if bill_topic:
                 st.markdown('##### Bill Topic')
                 st.markdown(bill_topic)
             else:
@@ -731,7 +731,7 @@ def display_org_dashboard_details(selected_rows):
             
             st.markdown('')
 
-            if bill_topic != 'Uncategorized':
+            if bill_topic:
                 st.markdown('##### Bill Topic')
                 st.markdown(bill_topic)
             else:


### PR DESCRIPTION
Added more sophistication to the bill topic function:
- Additional key word matches for topic labels
- Ability to apply multiple topic labels, rather than just one

Changed filter types for date_introduced and bill_event columns in the ag grid tables to date type format (closes #87)

Added cache decorator to bills page
- bills table now loads every 11.5 hours to align with cron job timeline (can change this in the future)
- should speed up load time; need to monitor this to see if it makes a meaningful difference 