### PR TITLE
Removed event type from appearing in the downloaded ics files

### DIFF
--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -861,7 +861,7 @@ def create_ics_file(events):
         
         # Build the description with your specified format
         description = f"Bill Name: {event_data.get('billName', 'No name provided')}\n"
-        description += f"Type: {event_data.get('type', 'Unknown')}\n"
+        #description += f"Type: {event_data.get('type', 'Unknown')}\n" -- turned off for now bc it was confusing when bills went to opposite house
         description += f"Event Details: {event_data.get('title', 'No details provided')}\n"
         
         # Format the date range for the description (check if there's an 'end' date)


### PR DESCRIPTION
Initially event type (Legislative, Assembly, Senate, and Letter Deadlines) was included in the event description of the downloaded event .ics file. However, I think it's confusing to include this when Assembly bills are being discussed in the opposite chamber at the moment (and vice versa), so I removed this to reduce any confusion as users being to pilot the tool.