### PR TITLE
fixed error occurring on calendar page

### DIFF
--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -233,6 +233,7 @@ span[data-baseweb="tag"]:has(span[title="Letter Deadline"]) {
 
 
 # Get unique bill numbers for the bill filter -- these are the bills that have events
+bill_events['bill_number'] = bill_events['bill_number'].astype(str)
 unique_bills = sorted(bill_events['bill_number'].unique())
 
 with st.sidebar.container():
@@ -449,6 +450,12 @@ def build_title(row):
 
 from datetime import datetime, timedelta
 
+def safe(val):
+    ''' Helper function to safely convert values to string or return None if NaN.'''
+    if pd.isna(val):
+        return None
+    return val
+
 
 def filter_events(selected_types, selected_bills_for_calendar, bill_filter_active):
     '''
@@ -502,14 +509,14 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                 #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                 'type': 'Assembly' if row['chamber_id'] == 1 else 'Senate',
                 'className': f"{event_class} {event_status}",  # Assign class -- corresponds to color coding from css file
-                'billNumber': row['bill_number'],
-                'billName': row['bill_name'],
-                'eventText': row['event_text'],
-                'eventTime': row['event_time'],
-                'status': row['status'], #this is bill status, not event status
-                'date_introduced': str(row['date_introduced']),
-                'letter_deadline': row['letter_deadline'],
-                'openstates_bill_id': row['openstates_bill_id'],
+                'billNumber': safe(row['bill_number']),
+                'billName': safe(row['bill_name']),
+                'eventText': safe(row['event_text']),
+                'eventTime': safe(row['event_time']),
+                'status': safe(row['status']),
+                'date_introduced': str(safe(row['date_introduced'])),
+                'letter_deadline': safe(row['letter_deadline']),
+                'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
             })
 
         # Add letter of support deadline events for all bill events
@@ -530,14 +537,14 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                     #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                     'type': 'Letter Deadline',
                     'className': "letter-deadline",  # Assign class -- corresponds to color coding from css file
-                    'billNumber': row['bill_number'],
-                    'billName': row['bill_name'],
-                    'eventText': row['event_text'],
-                    'eventTime': row['event_time'],
-                    'status': row['status'], #this is bill status, not event status
-                    'date_introduced': str(row['date_introduced']),
-                    'letter_deadline': row['letter_deadline'],
-                    'openstates_bill_id': 'N/A',
+                    'billNumber': safe(row['bill_number']),
+                    'billName': safe(row['bill_name']),
+                    'eventText': safe(row['event_text']),
+                    'eventTime': safe(row['event_time']),
+                    'status': safe(row['status']),
+                    'date_introduced': str(safe(row['date_introduced'])),
+                    'letter_deadline': safe(row['letter_deadline']),
+                    'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
                 })
 
     # If filtering by event type, not bill
@@ -553,7 +560,7 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                 'end': row['end'],  # this is the namer of the column in the leg events csv file
                 #'allDay': bool(row['allDay']), # All legislative events are all-day, which is already hardcoded in the csv file
                 'type': 'Legislative',
-                'className': f"{event_classes.get('Legislative', '')} event-normal", # Assign class -- corresponds to color coding from css file
+                'className': f"{event_classes.get('Legislative', '')} event-normal", # Assign class -- corresponds to color coding from css file            
                 'billNumber': 'N/A',
                 'billName': 'N/A',
                 'eventText': 'N/A',
@@ -562,7 +569,6 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                 'date_introduced': 'N/A',
                 'letter_deadline': 'N/A',
                 'openstates_bill_id': 'N/A',
-
             })
         
         # Add letter of support deadline events if selected
@@ -583,14 +589,14 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                         #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                         'type': 'Letter Deadline',
                         'className': "letter-deadline",  # Assign class -- corresponds to color coding from css file
-                        'billNumber': row['bill_number'],
-                        'billName': row['bill_name'],
-                        'eventText': row['event_text'],
-                        'eventTime': row['event_time'],
-                        'status': row['status'], #this is bill status, not event status
-                        'date_introduced': str(row['date_introduced']),
-                        'letter_deadline': row['letter_deadline'],
-                        'openstates_bill_id': 'N/A',
+                        'billNumber': safe(row['bill_number']),
+                        'billName': safe(row['bill_name']),
+                        'eventText': safe(row['event_text']),
+                        'eventTime': safe(row['event_time']),
+                        'status': safe(row['status']),
+                        'date_introduced': str(safe(row['date_introduced'])),
+                        'letter_deadline': safe(row['letter_deadline']),
+                        'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
 
                     })
 
@@ -613,15 +619,14 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                     #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                     'type': 'Assembly',
                     'className': f"{event_class} {event_status}",  # Assign class -- corresponds to color coding from css file
-                    'billNumber': row['bill_number'],
-                    'billName': row['bill_name'],
-                    'eventText': row['event_text'],
-                    'eventTime': row['event_time'],
-                    'status': row['status'], #this is bill status, not event status
-                    'date_introduced': str(row['date_introduced']),
-                    'letter_deadline': row['letter_deadline'],
-                    'openstates_bill_id': row['openstates_bill_id'],
-
+                    'billNumber': safe(row['bill_number']),
+                    'billName': safe(row['bill_name']),
+                    'eventText': safe(row['event_text']),
+                    'eventTime': safe(row['event_time']),
+                    'status': safe(row['status']),
+                    'date_introduced': str(safe(row['date_introduced'])),
+                    'letter_deadline': safe(row['letter_deadline']),
+                    'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
                 })
 
         # Add Senate bill events if selected
@@ -643,14 +648,14 @@ def filter_events(selected_types, selected_bills_for_calendar, bill_filter_activ
                     #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                     'type': 'Senate',
                     'className': f"{event_class} {event_status}",  # Assign class -- corresponds to color coding from css file
-                    'billNumber': row['bill_number'],
-                    'billName': row['bill_name'],
-                    'eventText': row['event_text'],
-                    'eventTime': row['event_time'],
-                    'status': row['status'], #this is bill status, not event status
-                    'date_introduced': str(row['date_introduced']),
-                    'letter_deadline': row['letter_deadline'],
-                    'openstates_bill_id': row['openstates_bill_id'],
+                    'billNumber': safe(row['bill_number']),
+                    'billName': safe(row['bill_name']),
+                    'eventText': safe(row['event_text']),
+                    'eventTime': safe(row['event_time']),
+                    'status': safe(row['status']),
+                    'date_introduced': str(safe(row['date_introduced'])),
+                    'letter_deadline': safe(row['letter_deadline']),
+                    'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
 
                 })
     
@@ -726,13 +731,14 @@ def create_bill_events(bill_events, include_letter_deadlines=True):
             #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
             'type': 'Assembly',
             'className': f"{event_class} {event_status}",  # Assign class -- corresponds to color coding from css file
-            'billNumber': row['bill_number'],
-            'billName': row['bill_name'],
-            'eventText': row['event_text'],
-            'eventTime': row['event_time'],
-            'status': row['status'], #this is bill status, not event status
-            'date_introduced': str(row['date_introduced']),
-            'letter_deadline': row['letter_deadline'],
+            'billNumber': safe(row['bill_number']),
+            'billName': safe(row['bill_name']),
+            'eventText': safe(row['event_text']),
+            'eventTime': safe(row['event_time']),
+            'status': safe(row['status']),
+            'date_introduced': str(safe(row['date_introduced'])),
+            'letter_deadline': safe(row['letter_deadline']),
+            'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
         }
 
         calendar_events.append(base_event)
@@ -751,13 +757,14 @@ def create_bill_events(bill_events, include_letter_deadlines=True):
                         #'allDay': bool(row['allDay']), #  Turned off bc events now have specific times
                         'type': 'Assembly',
                         'className': "letter-deadline",  # Assign class -- corresponds to color coding from css file
-                        'billNumber': row['bill_number'],
-                        'billName': row['bill_name'],
-                        'eventText': row['event_text'],
-                        'eventTime': row['event_time'],
-                        'status': row['status'], #this is bill status, not event status
-                        'date_introduced': str(row['date_introduced']),
-                        'letter_deadline': row['letter_deadline'],
+                        'billNumber': safe(row['bill_number']),
+                        'billName': safe(row['bill_name']),
+                        'eventText': safe(row['event_text']),
+                        'eventTime': safe(row['event_time']),
+                        'status': safe(row['status']),
+                        'date_introduced': str(safe(row['date_introduced'])),
+                        'letter_deadline': safe(row['letter_deadline']),
+                        'openstates_bill_id': safe(row.get('openstates_bill_id', 'N/A')),
                     }
                     
                     calendar_events.append(letter_deadline_event)


### PR DESCRIPTION
fixed error with bill_number datatype + added function to safely hand…le panda to json NAN values

Original error message: 
_TypeError: '<' not supported between instances of 'float' and 'str'
Traceback:
File "/usr/local/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
File "/usr/local/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 579, in code_to_exec
    exec(code, module.__dict__)
File "/app/main.py", line 100, in <module>
    pg.run()
File "/usr/local/lib/python3.10/site-packages/streamlit/navigation/page.py", line 303, in run
    exec(code, module.__dict__)
File "/app/calendar_page.py", line 236, in <module>
    unique_bills = sorted(bill_events['bill_number'].unique())_