### PR TITLE
Created advocacy hub page + other changes

### DIFF
--- a/app/advocacy_hub.py
+++ b/app/advocacy_hub.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Advocacy Hub
+Created on July 7, 2025
+@author: danyasherbini
+
+Page that features custom data from organizations using the Leg Tracker.
+"""
+
+import streamlit as st
+import pandas as pd
+from db.query import get_all_custom_bill_details
+from utils.aggrid_styler import draw_advocacy_grid
+
+# Ensure user info exists in the session (i.e. ensure the user is logged in)
+if 'authenticated' not in st.session_state:
+    st.error("User not authenticated. Please log in.")
+    st.stop()  # Stop execution if the user is not authenticated
+
+# Access user info from session state
+org_id = st.session_state.get('org_id')
+org_name = st.session_state['org_name']
+user_email = st.session_state['user_email']
+
+# Page title
+st.title("📣 Advocacy Hub")
+
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(""" 
+- This page displays custom advocacy information from organizations using the Legislation Tracker.
+- Only organizations with access to the Legislation Tracker can view this data.
+- You can filter the data by bill number and organization.
+- You can edit or add custom advocacy details for bills from your organization's dashboard.                                                  
+""")
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
+
+
+records = get_all_custom_bill_details()
+
+if records:
+    df = pd.DataFrame(records)
+
+    # Format dates
+    df["last_updated_on"] = pd.to_datetime(df["last_updated_on"]).dt.date
+    df["last_updated_at"] = pd.to_datetime(df["last_updated_at"]).dt.time
+
+    col1, col2, col3 = st.columns([4.5,.25,3.25])
+
+    with col1:
+        with st.container(border=True):
+            st.subheader("📣 Advocacy Details by Organization")
+            st.markdown(" ")
+
+            # Filters
+            with st.container(border=True):
+                    st.markdown("🔍 Filter")
+                    
+                    selected_bills = st.multiselect("Bill", sorted(df["bill_number"].dropna().unique()))
+                    selected_orgs = st.multiselect("Organization", sorted(df["last_updated_org_name"].dropna().unique()))
+
+                    if selected_bills:
+                        df = df[df["bill_number"].isin(selected_bills)]
+                    if selected_orgs:
+                        df = df[df["last_updated_org_name"].isin(selected_orgs)]
+
+            st.markdown(" ")
+
+            # Configure AgGrid table -- using Streamlit data editor instead
+            #draw_advocacy_grid(df)
+            
+            # Configure Streamlit dataframe
+            desired_order = ["last_updated_on", "last_updated_org_name", "bill_number", "org_position", "priority_tier", "assigned_to",
+                            "letter_of_support"]
+            
+            # Display only these columns in this order
+            df_display = df[desired_order]
+
+            # Sort by last_updated_on in descending order
+            df = df.sort_values(by="last_updated_on", ascending=False)
+
+            # Display table
+            st.data_editor(
+                df_display,
+                use_container_width=True,
+                column_config={
+                    "last_updated_on": st.column_config.DateColumn("Last Updated", format="MM-DD-YYYY", help="Date when these details were last updated by the organization"),
+                    "last_updated_org_name": st.column_config.Column("Organization", help="Organizations with access to the Legislation Tracker"),
+                    "bill_number": st.column_config.Column("Bill Number"),
+                    "org_position": st.column_config.Column("Position", help="Organization's position on the bill"),
+                    "priority_tier": st.column_config.Column("Priority", help="Priority tier assigned to the bill by the organization"),
+                    "assigned_to": st.column_config.Column("Point of Contact", help="Organization member assigned to this bill"),
+                    "letter_of_support": st.column_config.LinkColumn("Letter of Support", display_text="Letter of Support", help="Letter of Support provided by the organization"),
+                },
+                hide_index=True,
+                disabled=True  # Table is not editable
+            )
+
+    # Second column for vertical space between the two main sections
+    with col2:
+        st.markdown(" ")
+
+    with col3:
+        with st.container(border=True):
+            
+            st.subheader("📄 Letters of Support")
+            st.markdown(" ")
+            
+            # Group letters by bill
+            grouped = df[pd.notna(df["letter_of_support"])].groupby("bill_number")
+
+            for bill_number, group in grouped:
+                st.markdown(f"**{bill_number}**")
+                for _, row in group.iterrows():
+                    org_name = row["last_updated_org_name"]
+                    letter_link = row["letter_of_support"]
+                    st.markdown(f"- [{org_name}'s Letter of Support]({letter_link})")
+                st.markdown("---")  # horizontal divider between bills
+
+
+
+else:
+    st.info("No custom details found.")

--- a/app/bills.py
+++ b/app/bills.py
@@ -19,13 +19,20 @@ from utils.bills import display_bill_info_text
 from utils.bill_history import format_bill_history
 
 # Page title and description
-st.title('Bills')
+st.title('📝 Bills')
 
 current_session = '2025-2026'
 
-st.write(f"""This page shows California assembly and senate bill information for the {current_session} legislative session.
-Please note that the page may take a few moments to load.
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(f""" 
+- This page shows California assembly and senate bill information for the {current_session} legislative session.
+- Use the column filters to search for specific bills by bill number, author, topic, and more.    
+- Click on a bill to view additional details and add the bill to your dashboards.                                                               
+- Please note that this page may take a few moments to load due to the volume of data.                                              
 """)
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
 
 ############################ LOAD AND PROCESS BILLS DATA #############################
 

--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -23,13 +23,14 @@ import numpy as np
 
 # Show the page title and description
 # st.set_page_config(page_title='Legislation Tracker', layout='wide') # can add page_icon argument
-st.title('Calendar')
+st.title('📅 Calendar')
 
-st.markdown("This calendar displays overall legislative events and deadlines, as well as bill-specific events for the current session. Use the filters on the left to search for specific events.")
-
-with st.expander("Important notes about the calendar", expanded=False):
+with st.expander("About this page", icon="ℹ️", expanded=False):
     st.markdown(
         '''
+        This calendar displays overall legislative events and deadlines, as well as bill-specific events for the current session. Use the filters on the left in the sidebar to search for specific events.
+        
+        Important notes about the calendar:
         - **Time zone:** Events take place in Pacific Time but are displayed in your local time zone.
         - **All-day events:** Some events have no available time information and may be marked as "all-day" events.
         - **Updated events:** Events with a :pencil2: icon have had their time, location, room, or agenda order changed since the tool was last updated.
@@ -38,6 +39,8 @@ with st.expander("Important notes about the calendar", expanded=False):
         - **View:** For best experience, view calendar in full screen mode.
         '''
     )
+
+# Add space between expander and main content
 st.markdown(" ")
 st.markdown(" ")
 

--- a/app/committees.py
+++ b/app/committees.py
@@ -19,13 +19,16 @@ from utils.general import to_csv
 from utils.committees import display_committee_info_text
 
 # Page title and description
-st.title('Committees')
-st.write(
-    '''
-    This page shows California Assembly and Senate committee information (upcoming hearings, memberships, links). 
-    Please note that the page may take a few moments to load.
-    '''
-)
+st.title('🗣 Committees')
+
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(""" 
+- This page shows California Assembly and Senate committee information (upcoming hearings, memberships, links). 
+- Click on a committee to view additional details.                                               
+""")
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
 
 ############################ LOAD AND PROCESS COMMITTEE DATA #############################
 # Load committee membership data

--- a/app/db/query.py
+++ b/app/db/query.py
@@ -502,6 +502,28 @@ def save_custom_bill_details_with_timestamp(bill_number, org_position, priority_
         cursor.close()
         conn.close()
 
+##################################################################################
+
+def get_all_custom_bill_details():
+    """
+    Fetches all custom bill details for a specific bill from all organizations.
+    """
+    db_config = config('postgres')
+    conn = psycopg2.connect(**db_config)
+    cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    cursor.execute("""
+        SELECT * FROM public.bill_custom_details
+        ORDER BY bill_number ASC
+    """, )
+    
+    results = cursor.fetchall()
+
+    cursor.close()
+    conn.close()
+
+    return [dict(row) for row in results]
+
 
 ###################################################################################
 # DEPRECATED FUNCTIONS

--- a/app/home.py
+++ b/app/home.py
@@ -12,63 +12,122 @@ import streamlit as st
 ############################ TITLE & WELCOME TEXT #############################
 
 # Page title
-st.title('Welcome to the California Legislation Tracker')
+st.title('Welcome to the CA Legislation Tracker!')
 
-st.markdown("""
-Tired of clicking through endless rabbit holes on California legislative websites? Or scrolling through long PDF files? You're in luck! The CA Legislation Tracker is a comprehensive source for California bill data, pulling from various sources and updating in real time. 
-""")
-
-
-############################ HOW TO USE THE APP #############################
+############################### ABOUT THE APP ###############################
 st.divider()
-st.header("How to Use This App")
+st.markdown("### About")
 
-# key features
 st.markdown(
 """
-### Key Features
-- **Explore Bills:** Use the search and filtering tools to find bills relevant to your work.
-- **Track Progress:** Monitor the status and history of bills in real time.
-- **Build Your Dashboard:** Add bills to your private dashboard for quick access.
+The California Legislation Tracker is a custom web application built by [TechEquity](https://techequity.us) to help advocacy organizations enhance their legislative tracking and advocacy efforts. Key features include:
 """,
 unsafe_allow_html=True)
+
+col1, col2, col3, col4 = st.columns([1,1,1,1])
+
+with col1:
+    with st.container(border=True):
+        st.markdown("**Live Data Updates**")
+        st.markdown("Automatically collects and displays California legislative data and updates in real time.")
+
+with col2:
+    with st.container(border=True):
+        st.markdown("**Centralized Information Hub**")
+        st.markdown("Consolidated bill data in one platform, limiting the need to search across disparate sources.")
+
+with col3:
+    with st.container(border=True):
+        st.markdown("**Advanced Search & Filters**")
+        st.markdown("Search and filter data by various fields in order to more easily find specific bill information.")
+
+with col4:
+    with st.container(border=True):
+        st.markdown("**Bill Tracking**")
+        st.markdown("Track your organization’s advocacy work through auto-generated fields and custom data entry.")    
+
     
-# Pages
+############################### PAGE DESCRIPTIONS ################################
+st.divider()
 st.markdown("### Pages")
 
 # Access user info
 org_id = st.session_state.get('org_id')
 org_name = st.session_state['org_name']
 
-pages = [
-        {"label": "Bills", "icon": "📝", "description": "Search, sort, and filter bills.", "page": "bills.py"},
-        {"label": "Legislators", "icon": "💼", "description": "View information about legislators and their activity.", "page": "legislators.py"},
-        {"label": "Committees", "icon": "🗣", "description": "View information about committees and their activity.", "page": "committees.py"},
-        {"label": "Calendar", "icon": "📅", "description": "Check the legislative calendar for upcoming events.", "page": "calendar_page.py"},
-        {"label": "My Dashboard", "icon": "📌", "description": "Manage and track your selected bills.", "page": "my_dashboard.py"},
-        {"label": f"{org_name}'s Dashboard", "icon": "🏢", "description": "Collaborate with your team to track bills together.", "page": "org_dashboard.py"},
-    ]
+# Grouped pages
+grouped_pages = {
+    "Legislative Info": {
+        "description": "Access legislative data, all in one place.",
+        "pages": [
+            {"label": "Bills", "icon": "📝", "description": "Search, sort, and filter all bills, and add them to your dashboards for detailed tracking.", "page": "bills.py"},
+            {"label": "Legislators", "icon": "💼", "description": "View information about legislators and their staff.", "page": "legislators.py"},
+            {"label": "Committees", "icon": "🗣", "description": "View information about committees, their members, and upcoming hearing dates.", "page": "committees.py"},
+            {"label": "Calendar", "icon": "📅", "description": "Check the legislative calendar for upcoming legislative deadlines and bill-specific events.", "page": "calendar_page.py"},
+        ]
+    },
+    "Bill Tracking Tools": {
+        "description": "Keep track of bills and collaborate across organizations.",
+        "pages": [
+            {"label": "Advocacy Hub", "icon": "📣", "description": "View custom advocacy information from fellow organizations.", "page": "advocacy_hub.py"},
+            {"label": f"{org_name}'s Dashboard", "icon": "🏢", "description": "Collaborate with your team to track bills together on a shared organizational dashboard.", "page": "org_dashboard.py"},
+            {"label": "My Dashboard", "icon": "📌", "description": "Manage and track bills you care about on your personal dashboard.", "page": "my_dashboard.py"},
+        ]
+    }
+}
 
-# Loop through pages and display them as streamlit page_link buttons
-for item in pages:
-    col1, col_space, col2 = st.columns([1, 0.1, 4])  # Thin blank column between the two
-    with col1:
-        st.page_link(item["page"], label=item["label"], icon=item["icon"])
-    with col2:
-        st.markdown(item["description"])
+# Render grouped page links
+for group, content in grouped_pages.items():
+    st.markdown(f"**{group}**")
+    st.markdown(f"<span style='color:gray'>{content['description']}</span>", unsafe_allow_html=True)
+    
+    for item in content["pages"]:
+        col1, col_space, col2 = st.columns([1, 0.1, 4])
+        with col1:
+            st.page_link(item["page"], label=item["label"], icon=item["icon"])
+        with col2:
+            st.markdown(item["description"])
+    
+    st.markdown(" ")  # Add space between groups
+    
 
-
-
-############################# ABOUT TECH EQUITY ###############################
+################################ FAQs #################################
 st.divider()
 
 st.markdown("""
-## FAQs
+### FAQs
 """)
 
-st.expander("Where is the data sourced from?", expanded=False).markdown("We source data from the OpenStates REST API and directly from the California LegInfo websites.")
+st.expander("Where is the data in the CA Legislation Tracker sourced from?", expanded=False).markdown("We source data from the OpenStates REST API and directly from the California LegInfo websites.")
 
-st.expander("How often is the data updated?", expanded=False).markdown("Data is updated twice per day: first between 2-3 AM Pacific Time and again between 2-3 PM Pacific Time.")
+st.expander("How often is the CA Legislation Tracker updated?", expanded=False).markdown("""
+                                                                                         
+The main legislative data (i.e., Bills, Legislators, Committees) is updated twice per day: first between 2-3 AM Pacific Time and again between 2-3 PM Pacific Time. Freshness of data pulled from legislative sources such as LegInfo are subject to the update cadence of those sources, which may vary. Please refer to the "Last Updated" date on the Bills page for the best indication of when the original data was last refreshed.
+""")
+                                                                                         
+st.expander("I noticed some data was incorrect or outdated.", expanded=False).markdown("This is possible. The California legislative websites may contain errors, or may not be updated on a timely basis, so there may be discrepencies from time to time. We do our best to ensure accuracy. We encourage advocacy professionals to double check information such as timing and location of Assembly and Senate meetings and hearings, or other time-sensitive information. If you notice recurring issues, please contact us.")
 
-st.expander("I noticed some data was incorrect or outdated.", expanded=False).markdown("This is possible. The California legislative websites may contain errors, or may not be updated on a timely basis, so there may be discrepencies from time to time. We do our best to ensure accuracy. However, we encourage advocacy professionals to double check information such as timing and location of Assembly and Senate meetings and hearings, or other time-sensitive information. If you notice recurring issues, please contact info@techequity.us.")
+################################ CONTACT #################################
+st.divider()
 
+st.markdown("""
+### Contact
+""")
+
+st.markdown("""
+**Submit Feedback**
+            
+If you have a question, comment, or feature request for the CA Legislation Tracker, let us know by filling out our [feedback form](https://docs.google.com/forms/d/e/1FAIpQLSe0z74WPwG7PtXlOOkMolgXvi5QPjIs_s0OVcxzryjdp5HsFA/viewform?usp=dialog).         
+""")
+
+st.markdown(" ")
+
+
+st.markdown("""
+**Technical Support**
+            
+If you require immediate technical assistance or encounter an urgent issue while using the tool, please reach out to us via email so we can provide support:
+                                                                                                                               
+- Danya Sherbini, Lead Developer (danya@techequity.us)
+- Keirstan Schiedeck, Product Manager (keirstan@techequity.us)          
+""")

--- a/app/legislators.py
+++ b/app/legislators.py
@@ -15,12 +15,16 @@ from utils.general import to_csv
 
 
 # Show the page title and description
-st.title('Legislators')
-st.write(
-    '''
-    This page shows legislator information for the current legislative session. 
-    '''
-)
+st.title('💼 Legislators')
+
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(""" 
+- This page shows legislator information for the current legislative session.
+- Click on a legislator to view additional details, such as staff contact information.                                          
+""")
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
 
 # Load data
 def get_and_clean_leg_data():

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,8 @@ st.set_page_config(
 logo = './assets/logo.png'
 st.logo(
         logo,
-        link="https://techequity.us")
+        #link="https://calegtracker.org/home"
+        )
 
 # Extract query parameters
 query_params = st.query_params
@@ -69,6 +70,7 @@ if 'authenticated' not in st.session_state:
         signup_page()
     else:
         login_page()
+
 else:
     # Get org_id from session state
     org_id = st.session_state.get('org_id')
@@ -77,21 +79,33 @@ else:
     # Get organization info using the correct function
     org_info = get_organization_by_id(org_id) if org_id else None
 
-    # Add page navigation for the authenticated user
-    home = st.Page('home.py', title='Home', icon='🏠', url_path='home', default=(nav_page == "home")) 
-    bills = st.Page('bills.py', title='Bills', icon='📝', url_path='bills')
-    legislators = st.Page('legislators.py', title='Legislators', icon='💼', url_path='legislators')
-    calendar = st.Page('calendar_page.py', title='Calendar', icon='📅', url_path='calendar')
-    dashboard = st.Page('my_dashboard.py', title='My Dashboard', icon='📌', url_path='my_dashboard')
-    committees = st.Page('committees.py', title='Committees', icon='🗣', url_path='committees')
+    # Create grouped navigation structure
+    pages = {
+        "": [
+            st.Page('home.py', title='Home', icon='🏠', url_path='home', default=(nav_page == "home")), 
+        ],
+        "Legislative Info": [
+            st.Page('bills.py', title='Bills', icon='📝', url_path='bills'),
+            st.Page('legislators.py', title='Legislators', icon='💼', url_path='legislators'),
+            st.Page('committees.py', title='Committees', icon='🗣', url_path='committees'),
+            st.Page('calendar_page.py', title='Calendar', icon='📅', url_path='calendar'),
+        ],
+        "Bill Tracking Tools": [
+            st.Page('advocacy_hub.py', title='Advocacy Hub', icon='📣', url_path='advocacy_hub'),
+            st.Page(
+                'org_dashboard.py',
+                title=f"{org_info[1]} Dashboard" if org_info else "Organization Dashboard",
+                icon='🏢',
+                url_path='org_dashboard',
+                default=False
+            ),
+            st.Page('my_dashboard.py', title='My Dashboard', icon='📌', url_path='my_dashboard'),
 
-    if org_info:
-        org_dashboard = st.Page("org_dashboard.py", title=f"{org_info[1]} Dashboard", icon="🏢", url_path="org_dashboard")
-    else:
-        org_dashboard = st.Page("org_dashboard.py", title="Organization Dashboard", icon="🏢", url_path="org_dashboard", default=False)
+        ],
+    }
 
-    # Build navigation bar
-    pg = st.navigation([home, bills, legislators, committees, calendar, dashboard, org_dashboard])
+    # Build grouped sidebar navigation
+    pg = st.navigation(pages)
 
     # Clear query parameters after successful login to prevent infinite loops
     if st.session_state.get('connected'):

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -18,7 +18,18 @@ from utils.bill_history import format_bill_history
 
 
 # Page title
-st.title('My Dashboard')
+st.title('📌 My Dashboard')
+
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(f"""
+- Use this page to track bills relevant to you.
+- Only you can view this page and all bills saved to it.
+- To add bills to this dashboard, select a bill on the 📝 Bills page and then click the "Add to My Dashboard" button.
+- To add custom advocacy details to a bill, go to your 🏢 Organization Dashboard. Custom advocacy details are viewable on this page, but editable only from your 🏢 Organization Dashboard.
+""")
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
 
 # Ensure user info exists in the session (i.e. ensure the user is logged in)
 if 'authenticated' not in st.session_state:

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -28,7 +28,18 @@ org_name = st.session_state['org_name']
 user_email = st.session_state['user_email']
 
 # Page title
-st.title(f"{org_name}'s Dashboard")
+st.title(f"🏢 {org_name}'s Dashboard")
+
+st.expander("About this page", icon="ℹ️", expanded=False).markdown(f"""
+- Use this page to track bills relevant to your organization.
+- Anyone in your organization with access to the CA Legislation Tracker can view this page and all bills saved to it.
+- To add bills to this dashboard, select a bill on the 📝 Bills page and then click the "Add to {org_name} Dashboard" button.
+- To add custom advocacy details to a bill, select a bill on this dashboard and edit the "Custom Advocacy Details" section. This data is only editable from this page, but is viewable for bills on your 📌 My Dashboard and viewable to fellow organizations on the 📣 Advocacy Hub page.                                         
+""")
+
+# Add space between expander and main content
+st.markdown(" ")
+st.markdown(" ")
 
 # Clear dashboard button -- DISABLED FOR NOW BC IT MIGHT GET MESSY HAVING THIS OPTION WITH MANY USERS SHARING ONE ORG DASHBOARD. but if we want to add it, the clear button on the my dashboard works.
 #col1, col2 = st.columns([4, 1])

--- a/app/utils/aggrid_styler.py
+++ b/app/utils/aggrid_styler.py
@@ -238,3 +238,72 @@ def draw_committee_grid(
         key=key,
         css=css
     )
+
+
+
+
+############################################################
+
+def draw_advocacy_grid(
+        df,
+        formatter: dict = None,
+        #selection='single', -- selection turned off
+        #use_checkbox=True, -- turned off
+        #header_checkbox = True, -- turned off
+        fit_columns=True, # change to True to make all column width based on the variable and fit the entire table to the window frame
+        theme='streamlit', # options = streamlit, alpine, balham, material
+        height: int = 600,
+        wrap_text: bool = False,
+        auto_height: bool = False,
+        key=None,
+        css: dict = None
+):
+
+    # Reorder columns: move 'last_updated_org_name' (Organization) to second position
+    cols = list(df.columns)
+    if 'last_updated_org_name' in cols and 'bill_number' in cols:
+        cols.insert(1, cols.pop(cols.index('last_updated_org_name')))  # move org column to index 1 (second)
+        df = df[cols]
+
+    # Initialize the GridOptionsBuilder from the dataframe passed into the function
+    builder = GridOptionsBuilder().from_dataframe(df)
+
+    # Configure default column settings for all columns
+    builder.configure_default_column(
+        enableFilter=True,
+        filter='agTextColumnFilter',
+        floatingFilter=True, # floating filter: adds a row under the header row for the filter
+        columnSize='sizeToFit'
+        )
+    
+    # Configure special settings for certain columns (batch)
+    builder.configure_columns(['bill_custom_details_id','openstates_bill_id','last_updated_org_id','community_sponsor','coalition','action_taken','last_updated_at'],hide=True)
+    
+    # Configure special settings for individual columns 
+    builder.configure_column('bill_number',pinned='left',headerName = 'Bill Number')
+    builder.configure_column('last_updated_org_name',headerName = 'Organization',filter='agSetColumnFilter')
+    builder.configure_column('org_position',headerName = 'Position',filter='agSetColumnFilter')
+    builder.configure_column('priority_tier',headerName = 'Priority',filter='agSetColumnFilter')
+    builder.configure_column('assigned_to',headerName = 'Point of Contact: Name',filter='agSetColumnFilter')
+    builder.configure_column('last_updated_by',headerName = 'Point of Contact: Email',filter='agSetColumnFilter')
+    builder.configure_column('letter_of_support',headerName = 'Letter of Support',filter=None)
+    builder.configure_column('last_updated_on',headerName = 'Last Updated',filter=None)
+    
+    # Configure how user selects rows -- turned off for legislators table
+    #builder.configure_selection(selection_mode=selection, use_checkbox=use_checkbox) # no selection needed for legislator table
+    builder.configure_auto_height(autoHeight=False) # configure height of the table
+    
+    # Build the grid options dictionary
+    grid_options = builder.build()
+
+    return AgGrid(
+        df,
+        gridOptions=grid_options, # pass the grid options dictionary built above
+        update_mode=GridUpdateMode.SELECTION_CHANGED | GridUpdateMode.VALUE_CHANGED, # ensures the df is updated dynamically
+        allow_unsafe_jscode=True,
+        fit_columns_on_grid_load=fit_columns,
+        height=height,
+        theme=theme,
+        key=key,
+        css=css
+    )

--- a/app/utils/my_dashboard.py
+++ b/app/utils/my_dashboard.py
@@ -158,7 +158,7 @@ def display_dashboard_details(selected_rows):
     custom_details = get_custom_bill_details_with_timestamp(openstates_bill_id, org_id)
 
     # Form for custom user-entered fields
-    st.markdown('#### Custom Bill Details')
+    st.markdown('#### Custom Advocacy Details')
     st.markdown(f'This section contains information entered by members of your organization. <span title="These fields are only editable from your Organization Dashboard." style="cursor: help;">💬</span>', unsafe_allow_html=True)
     
     with st.container(key='custom_fields_container', border=True):

--- a/app/utils/org_dashboard.py
+++ b/app/utils/org_dashboard.py
@@ -154,7 +154,7 @@ def display_org_dashboard_details(selected_rows):
     custom_details = get_custom_bill_details_with_timestamp(openstates_bill_id, org_id)
 
     # Form for custom user-entered fields
-    st.markdown('#### Custom Bill Details')
+    st.markdown('#### Custom Advocacy Details')
     st.markdown('Use this section to enter custom details for this bill. <span title="These fields are also viewable on the My Dashboard page if you add this bill to your personal dashboard, but are only editable from your Organization Dashboard." style="cursor: help;">💬</span>', unsafe_allow_html=True)
 
     with st.form(key='custom_fields', clear_on_submit=False, enter_to_submit=True, border=True):


### PR DESCRIPTION
- Created advocacy hub page, which features custom advocacy details from all orgs (Closes #138)
- Refactored home page
- Restructured sidebar navigation to group pages (Closes #109)
- Added "About this page" expanders to every page (Closes #140)
- Added icon to every page title to help with page differentiation/recognition (Closes #109)
- Removed tech equity hyperlink from logo (Closes #106)