### PR TITLE
Bill topics display in details container

### DIFF
--- a/app/utils/bills.py
+++ b/app/utils/bills.py
@@ -11,6 +11,7 @@ Function for displaying bill details on the Bills Page.
 import streamlit as st
 import pandas as pd
 from db.query import add_bill_to_dashboard, add_bill_to_org_dashboard, BILL_COLUMNS
+from .general import bill_topic_grid
 
 def display_bill_info_text(selected_rows):
     '''
@@ -48,6 +49,10 @@ def display_bill_info_text(selected_rows):
     org_name = st.session_state.get('org_name', 'Unknown Org')
     user_email = st.session_state.get('user_email', 'Unknown User')
     
+
+    # # Prepare bill topics for markdown display
+    # bill_topic = ''.join([f"- {t}" for t in bill_topic])
+
     # Display Bill Info Below the Table
     st.markdown('### Bill Details')
     st.divider()
@@ -142,12 +147,8 @@ def display_bill_info_text(selected_rows):
             
             st.markdown('')
 
-            if bill_topic is not None:
-                st.markdown('##### Bill Topic')
-                st.markdown(bill_topic)
-            else:
-                st.markdown('#### ')
-                st.markdown('')
+            st.markdown('##### Bill Topic')
+            bill_topic_grid(bill_topic)
 
             st.markdown('')
 

--- a/app/utils/general.py
+++ b/app/utils/general.py
@@ -136,3 +136,71 @@ def transform_name(name):
         return f"{parts[-1]}, {' '.join(parts[0:-1])}"
     else:
         return f"{parts[-2]}, {' '.join(parts[0:-2])}, {parts[-1].replace(',', '')}"
+    
+###############################################################################
+
+def get_topic_color(topic):
+    # Handle empty/null case first (returns light gray)
+    if not topic or topic == "0":
+        return "#f0f0f0"  # Light gray for empty/default
+    
+    # Define color mapping for each category 
+    color_map = {
+        "AI": "#E1D5E7",  # Soft lavender
+        "Discrimination": "#F5C2C7",  # Dusty rose
+        "Education": "#B8D8EB",  # Pale sky blue
+        "Environment": "#C3E6C3",  # Mint green
+        "Health": "#F8D6B3",  # Peach
+        "Housing": "#C9C9EE",  # Periwinkle
+        "Labor": "#FFE0B3",  # Pale amber
+        "Data, Surveillence, Privacy": "#B3E0E6",  # Powder blue
+        "Disinformation": "#D4C5C0",  # Warm gray
+        "Judicial System": "#B3B3D6",  # Soft denim
+        "Safety": "#E6B3B3",  # Blush pink
+        "Other": "#E0E0E0"   # Light gray
+    }
+    
+    # Return the corresponding color or default if not found
+    return color_map.get(topic, "#FFFFFF")  # ultimate fallback on white if needed
+
+def bill_topic_grid(bill_topic_lst):
+    # TODO: decide if we want to display something for bills without set topics
+    if not bill_topic_lst:
+        bill_topic_lst = ["0"]  # Default for empty list
+    
+    # Always use 3 columns layout
+    cols = st.columns(3)
+    
+    for idx, topic in enumerate(bill_topic_lst):
+        # Use modulo to select 1st, 2nd or 3rd column
+        col = cols[idx % 3]
+
+        # Transform topic text for display assuming the null case is in scope
+        display_text = topic if topic != "0" else "None set"
+        
+        with col:
+            container = st.container() # Create a container to fill with HTML
+            container.markdown(
+                f"""
+                <div style="
+                    background-color: {get_topic_color(topic)};
+                    padding: 20px;
+                    border-radius: 5px;
+                    text-align: center;
+                    height: 70px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                ">
+                    {display_text}
+                </div>
+                """,
+                unsafe_allow_html=True
+            )
+    
+    # Visual indication of empty slots
+    remaining_slots = (3 - (len(bill_topic_lst) % 3)) % 3
+    if remaining_slots > 0 and len(bill_topic_lst) > 0:
+        for i in range(remaining_slots):
+            cols[(len(bill_topic_lst) + i) % 3].container()
+    return

--- a/app/utils/my_dashboard.py
+++ b/app/utils/my_dashboard.py
@@ -11,6 +11,7 @@ Utility function for displaying bill details on the MY DASHBOARD page.
 import streamlit as st
 import pandas as pd
 from db.query import get_custom_bill_details_with_timestamp, remove_bill_from_dashboard
+from .general import bill_topic_grid
 
 def display_dashboard_details(selected_rows):
     '''
@@ -138,12 +139,8 @@ def display_dashboard_details(selected_rows):
             
             st.markdown('')
 
-            if bill_topic:
-                st.markdown('##### Bill Topic')
-                st.markdown(bill_topic)
-            else:
-                st.markdown('#### ')
-                st.markdown('')
+            st.markdown('##### Bill Topic')
+            bill_topic_grid(bill_topic)
 
             st.markdown('')
 

--- a/app/utils/org_dashboard.py
+++ b/app/utils/org_dashboard.py
@@ -12,6 +12,7 @@ Utility function for displaying bill details on the ORG DASHBOARD page.
 import streamlit as st
 import pandas as pd
 from db.query import get_custom_bill_details_with_timestamp, save_custom_bill_details_with_timestamp, remove_bill_from_org_dashboard
+from .general import bill_topic_grid
 
 def display_org_dashboard_details(selected_rows):
     '''
@@ -44,7 +45,7 @@ def display_org_dashboard_details(selected_rows):
     org_id = st.session_state.get('org_id', 'Unknown Org ID')
     org_name = st.session_state.get('org_name', 'Unknown Org')
     user_email = st.session_state.get('user_email', 'Unknown User')
-
+    
     # Display Bill Info Below the Table
     st.markdown('### Bill Details')
     st.divider()
@@ -138,12 +139,8 @@ def display_org_dashboard_details(selected_rows):
             
             st.markdown('')
 
-            if bill_topic:
-                st.markdown('##### Bill Topic')
-                st.markdown(bill_topic)
-            else:
-                st.markdown('#### ')
-                st.markdown('')
+            st.markdown('##### Bill Topic')
+            bill_topic_grid(bill_topic)
 
             st.markdown('')
 


### PR DESCRIPTION
- Default displays a card when no topic is found
- Define a color map for known bill topics and generate colored "cards" for each topic