### PR TITLE
Fixed get_working_group_bills()

### DIFF
--- a/app/calendar_page.py
+++ b/app/calendar_page.py
@@ -92,7 +92,7 @@ leg_events = load_leg_events()
 # Load events specific to individual bills
 @st.cache_data(ttl=10 * 60 * 60) # Cache for 10 hours
 def load_bill_events():
-    bills = query_table('public', 'processed_bills_from_snapshot_2025_2026') # Get bill info from processed_bills table
+    bills = query_table('public', 'bills_2025_2026') # Get bill info from processed_bills table
     events = query_table('ca_dev', 'bill_schedule') # Get bill events from bill_schedule table
 
     # Subset columns we want from each table

--- a/app/db/query.py
+++ b/app/db/query.py
@@ -756,6 +756,7 @@ def get_working_group_bills():
                 b.bill_history,
                 b.bill_event,
                 b.event_text,
+                b.assigned_topics,
                 b.last_updated_on
             FROM public.bills_2025_2026 b
             INNER JOIN public.working_group_dashboard wgd

--- a/app/db/sql/views/process_bills_from_snapshot.sql
+++ b/app/db/sql/views/process_bills_from_snapshot.sql
@@ -13,7 +13,7 @@
 
 -- Output: 
 ----- schema: public
------ view name: processed_bills_from_snapshot_{leg_session}
+----- view name: bills_{leg_session}
 
 DROP VIEW IF EXISTS bills_2025_2026;
 CREATE OR REPLACE VIEW bills_2025_2026 AS


### PR DESCRIPTION
Function was missing a reference to the new assigned_topics column in bills_2025_2026, which was causing the saved working group bills to not appear on the wg page. Closes #163.