### PR TITLE
Converted bill topic from set to string

### DIFF
--- a/app/ai_wg_dashboard.py
+++ b/app/ai_wg_dashboard.py
@@ -78,12 +78,15 @@ if not wg_bills.empty:
     wg_bills['last_updated_on'] = pd.to_datetime(wg_bills['last_updated_on']).dt.strftime('%Y-%m-%d') # Remove timestamp from last_updated_on
 
     # Minor data processing to match bills table
-    # wg_bills = get_bill_topics_multiple(wg_bills, keyword_dict= keyword_to_topics, keyword_regex=global_keyword_regex)  # Get bill topics
-    # Wrangle assigned-topic string to a Python list for web app manipulation
-    wg_bills['bill_topic'] = wg_bills['assigned_topics'].apply(lambda x: set(x.split("; ")) if x else ["Other"])
-    bills = wg_bills.drop(columns=['assigned_topics'])
-
-    wg_bills['bill_history'] = wg_bills['bill_history'].apply(format_bill_history) #Format bill history
+    
+    # Convert assigned_topics into string for AgGrid. AgGrid cannot hash Python lists or sets.
+    wg_bills['bill_topic'] = wg_bills['assigned_topics'].apply(lambda x: "; ".join(x.split("; ")) if pd.notna(x) and x.strip() else "Other")
+    
+    # Drop the original assigned_topics column from the display table
+    wg_bills = wg_bills.drop(columns=['assigned_topics'])
+    
+    # Format bill history
+    wg_bills['bill_history'] = wg_bills['bill_history'].apply(format_bill_history)
 
     # Default sorting: by upcoming bill_event
     wg_bills = wg_bills.sort_values(by='bill_event', ascending=False)

--- a/app/bills.py
+++ b/app/bills.py
@@ -56,8 +56,10 @@ def load_bills_table():
     bills['bill_event'] = pd.to_datetime(bills['bill_event']).dt.strftime('%Y-%m-%d') # Remove timestamp from bill_event
     bills['last_updated_on'] = pd.to_datetime(bills['last_updated_on']).dt.strftime('%Y-%m-%d') # Remove timestamp from last_updated_on
 
-    # Wrangle assigned-topic string to a Python list for web app manipulation
-    bills['bill_topic'] = bills['assigned_topics'].apply(lambda x: set(x.split("; ")) if x else ["Other"])
+    # Convert assigned_topics into string for AgGrid. AgGrid cannot hash Python lists or sets.
+    bills['bill_topic'] = bills['assigned_topics'].apply(lambda x: "; ".join(x.split("; ")) if pd.notna(x) and x.strip() else "Other")
+        
+    # Drop the original assigned_topics column from the display table
     bills = bills.drop(columns=['assigned_topics'])
     
     # Format bill history

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -69,10 +69,14 @@ db_bills['bill_event'] = pd.to_datetime(db_bills['bill_event']).dt.strftime('%Y-
 db_bills['last_updated_on'] = pd.to_datetime(db_bills['last_updated_on']).dt.strftime('%Y-%m-%d') # Remove timestamp from last_updated_on
 
 # Minor data processing to match bills table
-# Wrangle assigned-topic string to a Python list for web app manipulation
-db_bills['bill_topic'] = db_bills['assigned_topics'].apply(lambda x: set(x.split("; ")) if x else ["Other"])
+# Convert assigned_topics into string for AgGrid. AgGrid cannot hash Python lists or sets.
+db_bills['bill_topic'] = db_bills['assigned_topics'].apply(lambda x: "; ".join(x.split("; ")) if pd.notna(x) and x.strip() else "Other")
+    
+# Drop the original assigned_topics column from the display table
 db_bills = db_bills.drop(columns=['assigned_topics'])
-db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history) #Format bill history
+
+#Format bill history
+db_bills['bill_history'] = db_bills['bill_history'].apply(format_bill_history) 
 
 # Default sorting: by upcoming bill_event
 db_bills = db_bills.sort_values(by='bill_event', ascending=False)

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -66,11 +66,14 @@ org_db_bills['bill_event'] = pd.to_datetime(org_db_bills['bill_event']).dt.strft
 org_db_bills['last_updated_on'] = pd.to_datetime(org_db_bills['last_updated_on']).dt.strftime('%Y-%m-%d') # Remove timestamp from last_updated_on
 
 # Minor data processing to match bills table
-# Wrangle assigned-topic string to a Python list for web app manipulation
-org_db_bills['bill_topic'] = org_db_bills['assigned_topics'].apply(lambda x: set(x.split("; ")) if x else ["Other"])
+# Convert assigned_topics into string for AgGrid. AgGrid cannot hash Python lists or sets.
+org_db_bills['bill_topic'] = org_db_bills['assigned_topics'].apply(lambda x: "; ".join(x.split("; ")) if pd.notna(x) and x.strip() else "Other")
+    
+# Drop the original assigned_topics column from the display table
 org_db_bills = org_db_bills.drop(columns=['assigned_topics'])
 
-org_db_bills['bill_history'] = org_db_bills['bill_history'].apply(format_bill_history) #Format bill history
+#Format bill history
+org_db_bills['bill_history'] = org_db_bills['bill_history'].apply(format_bill_history) 
 
 # Default sorting: by upcoming bill_event
 org_db_bills = org_db_bills.sort_values(by='bill_event', ascending=False)


### PR DESCRIPTION
Looks like AgGrid cannot hash lists or sets, so it was throwing an error when trying to display the tables due to the bill topic column, which was a set. Now each item in bill topic column is a semicolon separated string. Closes #166 