### PR TITLE
Resolve dependabot alerts for NLP packages

### DIFF
--- a/app/nlp-requirements.txt
+++ b/app/nlp-requirements.txt
@@ -75,12 +75,12 @@ jupyter_client==8.6.3
 jupyter_core==5.8.1
 jupyter_server==2.16.0
 jupyter_server_terminals==0.5.3
-jupyterlab==4.4.4
+jupyterlab==4.4.8
 jupyterlab_pygments==0.3.0
 jupyterlab_server==2.27.3
 jupyterlab_widgets==3.0.15
 kaleido==1.0.0
-keras==3.10.0
+keras==3.11.3
 kiwisolver==1.4.8
 libclang==18.1.1
 logistro==1.1.0
@@ -184,7 +184,7 @@ tinycss2==1.4.0
 tokenizers==0.21.2
 toml==0.10.2
 tomli==2.2.1
-torch==2.7.1
+torch==2.8.0
 tornado==6.5.1
 tqdm==4.67.1
 traitlets==5.14.3


### PR DESCRIPTION
Local manual testing confirms that NLP functionality is stable after bumping up dependencies (torch, keras, jupyterlab)
