### PR TITLE
Fix 2 bugs in bill history

### DIFF
--- a/app/db/sql/materialized views/process_bills_from_snapshot_mv.sql
+++ b/app/db/sql/materialized views/process_bills_from_snapshot_mv.sql
@@ -59,7 +59,7 @@ latest_status AS (
         openstates_bill_id, 
         description AS status
     FROM app.bill_history
-    ORDER BY openstates_bill_id, action_date DESC
+    ORDER BY openstates_bill_id, action_order DESC
 ),
 
 -- Aggregate full bill history

--- a/app/db/sql/views/process_bills_from_snapshot.sql
+++ b/app/db/sql/views/process_bills_from_snapshot.sql
@@ -58,7 +58,7 @@ latest_status AS (
         openstates_bill_id, 
         description AS status
     FROM app.bill_history
-    ORDER BY openstates_bill_id, action_date DESC
+    ORDER BY openstates_bill_id, action_order DESC
 ),
 
 -- Aggregate full bill history

--- a/app/utils/bill_history.py
+++ b/app/utils/bill_history.py
@@ -18,14 +18,14 @@ def format_bill_history(bill_history):
     if not bill_history:
         return ""
 
-    # Split entries using ", " (assuming this is how they are separated)
-    entries = bill_history.split(", ")
+    # Split entries using a more specific pattern that looks for ", " followed by a date
+    entries = re.split(r',\s*(?=\d{4}-\d{2}-\d{2}\s*>>)', bill_history)
 
     # Process entries into tuples (date, event)
     formatted_entries = []
     for entry in entries:
         # Ensure the format is `YYYY-MM-DD >> Event`
-        match = re.match(r"^(\d{4}-\d{2}-\d{2})\s*>>\s*(.+)", entry)
+        match = re.match(r"^(\d{4}-\d{2}-\d{2})\s*>>\s*(.+)", entry.strip())
         if match:
             date, event = match.groups()
             formatted_entries.append((date, event))
@@ -38,6 +38,8 @@ def format_bill_history(bill_history):
 
 
 ##########################################################################################################################################
+
+## DEPRECATED FUNCTIONS
 
 def format_bill_history_dashboard(bill_history):
     '''


### PR DESCRIPTION
1. format_bill_history() regex usage was resulting in some bill action text being cut off from db to app display
2. process_bills_from_snapshot_mv.sql was ordering bill status by action_date, not action_order, which resulted in some incorrect statuses when there are multiple bill actions on the same date. Changed to order by action_order instead.