### PR TITLE
Update requirements.txt

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,6 +11,7 @@ streamlit-google-auth==1.1.8
 paramiko==3.4.1
 python-dotenv==0.21.0
 ics==0.7.2
+tatsu==5.8.3
 pyyaml==6.0.2
 
 # on hold / not using currently


### PR DESCRIPTION
Added tatsu 5.8.3, which is a requirement for ics 0.7.2. Was getting error bc ics was defaulting to old version of tatsu, which has since been upgraded. Closes #304 