### PR TITLE
add util function to disable lastpass autofill

### DIFF
--- a/app/advocacy_hub.py
+++ b/app/advocacy_hub.py
@@ -13,8 +13,12 @@ import pandas as pd
 from db.query import get_all_custom_bill_details
 from utils.aggrid_styler import draw_advocacy_grid
 from utils.profiling import track_rerun
+from utils.lastpass import disable_lastpass
 
 track_rerun("Advocacy Hub")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Ensure user info exists in the session (i.e. ensure the user is logged in)
 if 'authenticated' not in st.session_state:

--- a/app/ai_wg_dashboard.py
+++ b/app/ai_wg_dashboard.py
@@ -22,9 +22,13 @@ from utils.ai_working_group import display_working_group_bill_details
 from utils.css_utils import load_css_with_fallback, DEFAULT_FALLBACK_CSS
 from utils.profiling import timer, profile, show_performance_metrics, track_rerun, track_event
 from utils.table_display import initialize_filter_state, display_bill_filters, apply_bill_filters, display_bills_table
+from utils.lastpass import disable_lastpass
 
 track_rerun("AI Working Group Dashboard")
 #################################### PAGE SETUP ####################################
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Load custom CSS with fallback
 load_css_with_fallback(

--- a/app/bills.py
+++ b/app/bills.py
@@ -16,6 +16,7 @@ from utils.bills import display_bill_info_text
 from utils.bill_history import format_bill_history
 from utils.profiling import timer, profile, track_rerun, track_event
 from utils.table_display import initialize_filter_state, display_bill_filters, apply_bill_filters, display_bills_table
+from utils.lastpass import disable_lastpass
 
 # Page title and description
 st.title('📝 Bills')
@@ -35,6 +36,9 @@ st.markdown(" ")
 
 ############################ LOAD AND PROCESS BILLS DATA #############################
 track_rerun("Bills")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 @profile("DB - Fetch bills table data")
 @st.cache_data(show_spinner="Loading bills data...",ttl=60 * 60 * 6) # Cache bills data and refresh every 6 hours

--- a/app/committees.py
+++ b/app/committees.py
@@ -18,6 +18,7 @@ from utils import aggrid_styler
 from utils.general import to_csv
 from utils.committees import display_committee_info_text, initialize_filter_state, display_committee_filters, apply_committee_filters, display_committee_table
 from utils.profiling import timer, profile, show_performance_metrics, track_rerun, track_event
+from utils.lastpass import disable_lastpass
 
 # Page title and description
 st.title('🗣 Committees')
@@ -33,6 +34,9 @@ st.markdown(" ")
 
 ############################ LOAD AND PROCESS COMMITTEE DATA #############################
 track_rerun("Committees")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Load committee membership data
 @profile("DB - Fetch COMMITTEE table data")

--- a/app/legislators.py
+++ b/app/legislators.py
@@ -16,6 +16,7 @@ from utils.general import to_csv, transform_name
 from utils.legislators import display_legislator_info_text
 from utils.profiling import timer, profile, show_performance_metrics, track_rerun, track_event
 from utils.legislators import initialize_filter_state, display_legislator_filters, apply_legislator_filters, display_legislator_table
+from utils.lastpass import disable_lastpass
 
 
 ############################ SESSION STATE #############################
@@ -57,6 +58,9 @@ st.markdown(" ")
 
 ############################ LOAD AND PROCESS DATA #############################
 track_rerun("Legislators")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Load data
 @profile("DB - Fetch LEGISLATOR table data")

--- a/app/my_dashboard.py
+++ b/app/my_dashboard.py
@@ -16,8 +16,12 @@ from utils.my_dashboard import display_dashboard_details
 from utils.bill_history import format_bill_history
 from utils.profiling import timer, profile, track_rerun, track_event
 from utils.table_display import initialize_filter_state, display_bill_filters, apply_bill_filters, display_bills_table
+from utils.lastpass import disable_lastpass
 
 track_rerun("My Dashboard")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Page title
 st.title('📌 My Dashboard')

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -15,9 +15,13 @@ from utils.org_dashboard import display_org_dashboard_details
 from utils.bill_history import format_bill_history
 from utils.profiling import timer, profile, track_rerun, track_event
 from utils.table_display import initialize_filter_state, display_bill_filters, apply_bill_filters, display_bills_table
+from utils.lastpass import disable_lastpass
 
 
 track_rerun("Org Dashboard")
+
+# Disable LastPass auto-fill
+disable_lastpass()
 
 # Ensure user info exists in the session (i.e. ensure the user is logged in)
 if 'authenticated' not in st.session_state:

--- a/app/utils/lastpass.py
+++ b/app/utils/lastpass.py
@@ -1,0 +1,23 @@
+"""
+lastpass.py
+date: March 3, 2026
+
+Utility function to disable lastpass auto-fill on all input fields in the Streamlit app. 
+This is necessary to prevent LastPass from interfering with the user experience, especially on dashboards / when filtering data.
+"""
+
+
+import streamlit as st
+
+def disable_lastpass():
+    st.markdown("""
+        <script>
+        const observer = new MutationObserver(() => {
+            document.querySelectorAll('input').forEach(el => {
+                el.setAttribute('data-lpignore', 'true');
+                el.setAttribute('autocomplete', 'off');
+            });
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        </script>
+    """, unsafe_allow_html=True)


### PR DESCRIPTION
Add utility function to disable last pass browser auto-fill from filling in filter fields on main pages. Was not able to test bc last pass was not filling in my fields like it is for other users. Might be something to address on last pass settings instead if this is not effective.