### PR TITLE
add warning message in case of caching issues upon bill selection

### DIFF
--- a/app/utils/org_dashboard.py
+++ b/app/utils/org_dashboard.py
@@ -12,13 +12,28 @@ import streamlit as st
 import pandas as pd
 from db.query import get_custom_bill_details_with_timestamp, save_custom_bill_details_with_timestamp, remove_bill_from_org_dashboard, get_letter_history, add_letter_to_history, get_bill_activity_history, get_org_dashboard_bills
 from .general import bill_topic_grid, clean_markdown
-from .profiling import profile, timer
+from .profiling import profile, timer, logging
+logger = logging.getLogger(__name__)
 
 @profile("utils/org_dashboard.py - display_org_dashboard_details")
 def display_org_dashboard_details(selected_rows):
     '''
     Displays bill details on the ORG DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
     '''
+    # Check if selected_rows is None or empty before proceeding
+    if selected_rows is None or selected_rows.empty:
+        return
+    
+    required_cols = ['openstates_bill_id', 'bill_number', 
+                        'bill_name', 'author', 'coauthors', 'status', 'date_introduced', 
+                        'leg_session', 'chamber', 'leginfo_link', 'bill_text', 
+                        'bill_history', 'bill_topic', 'bill_event', 'event_text', 'last_updated_on']
+    missing = [c for c in required_cols if c not in selected_rows.columns]
+    if missing:
+        st.warning("⚠️ Bill details unavailable. Try refreshing the page.")
+        logger.warning(f"display_org_dashboard_details: missing columns {missing}")
+        return
+
     # Extract the values from the selected row
     openstates_bill_id = selected_rows['openstates_bill_id'].iloc[0]
     bill_number = selected_rows['bill_number'].iloc[0]


### PR DESCRIPTION
On 3/30 and 3/31, error message appeared on org dashboard page when selecting a bill (see below). After some investigation, this appears to be the result of a caching issue in Streamlit. Could be a knock-on effect from recent caching/clear/rerun/session_state changes implemented in PR #358. Upon refreshing the page, the error no longer appears (and I have not been able to recreate the error since).

Attempted to address this by updating utils/org_dashboard.py display_org_dashboard_details() function to handle if any columns are "missing" due to stale cache or session state and display a warning message to the user instructing them to refresh. Closes #359.

```
KeyError: 'bill_topic'
Traceback:

File "/app/main.py", line 126, in <module>
    pg.run()
File "/usr/local/lib/python3.12/site-packages/streamlit/navigation/page.py", line 303, in run
    exec(code, module.__dict__)  # noqa: S102
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/org_dashboard.py", line 148, in <module>
    display_org_dashboard_details(selected_bill_data)
File "/app/utils/profiling.py", line 139, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
File "/app/utils/org_dashboard.py", line 35, in display_org_dashboard_details
    bill_topic = selected_rows['bill_topic'].iloc[0]
                 ~~~~~~~~~~~~~^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/pandas/core/frame.py", line 4102, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
```