### PR TITLE
bump Gunicorn worker count for Dockerfile

### DIFF
--- a/calendar-feed/Dockerfile
+++ b/calendar-feed/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 5000
 
 CMD ["gunicorn", "app:create_app()", \
      "--bind", "0.0.0.0:5000", \
-     "--workers", "2", \
+     "--workers", "4", \
      "--timeout", "30", \
      "--access-logfile", "-", \
      "--error-logfile", "-"]


### PR DESCRIPTION
Ran `EXPLAIN (ANALYZE, BUFFERS)` on each of the custom feeds:
- `feed/org/<token>`
- `feed/user/<token>`
- `feed/working-group/<token>`

==> Average planning + execution time ~7ms per feed request

150 approved users x 3 dashboard feeds per user x 1 Postgres request per dashboard feed x 10ms per request / 4 workers = 0.80 sec est. execution time (compared to 1.6 sec)

Increasing Gunicorn worker count will maintain app latency for (a) WG training event and (b) typical daily request volume

Additionally, a separate DO connection pool of size 6 (50% headroom above 4 workers) has already been configured.