### PR TITLE
Cal feed pre-deployment stabilization + enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *./__pycache__/
 *.py[cod]
 *$py.class
+*.dump
 
 # C extensions
 *.so

--- a/calendar-feed/deadline_builder.py
+++ b/calendar-feed/deadline_builder.py
@@ -45,7 +45,6 @@ def build_deadline_event(
         "uid",
         f"deadline-{row['hearing_id']}-{row['openstates_bill_id']}-{deadline_type}@legtracker",
     )
-
     label = (row.get("deadline_type") or "LETTER").upper()
     chamber_tag = _chamber_prefix(row.get("chamber_id"))
     bill_number = row.get("bill_number")
@@ -87,6 +86,7 @@ def build_deadline_event(
         "**Bill Details**\n"
         f"Bill: {bill_number} | {bill_name}\n"
         f"Author: {bill_author}\n"
+        f"Footnotes: {row.get('footnote') or 'N/A'}\n"
         f"{org_section_plain}\n"  # Double newline
         f"**Hearing Details**\n"
         f"Committee: {chamber_tag} {hearing_name}\n"
@@ -100,6 +100,7 @@ def build_deadline_event(
         f"<b>Bill Details:</b><br>"
         f"Bill: {bill_number} | {bill_name}<br><br>"
         f"Author: <br>"
+        f"Footnotes: {row.get('footnote') or 'N/A'}<br>"
         f"{org_section_html}<br>"  # Double newline
         f"<b>Hearing Details:</b><br>"
         f"Committee: {chamber_tag} {hearing_name}<br>"

--- a/calendar-feed/hearing_builder.py
+++ b/calendar-feed/hearing_builder.py
@@ -50,9 +50,7 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
     parts = []
     html_parts = []
 
-    NOTES_NA = "\nNotes: N/A"
-    NOTES_NA_HTML = "<br><b>Notes:</b> N/A"
-
+    # -- Step 1: get core details
     if h.get("hearing_time_verbatim"):
         hearing_time = h["hearing_time_verbatim"].replace("m.", "m. PT")
         parts.append(f"Time: {hearing_time}")
@@ -65,7 +63,7 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
             f"<br><b>Committee info:</b> <a href=\"{h['committee_webpage']}\">{h['committee_webpage']}</a>"
         )
 
-    # Collect unique deadlines across rows (future-proof for multiple types)
+    # -- Step 2: collect unique deadlines across rows (future-proof for multiple types)
     seen_deadlines = set()
     for row in rows:
         if row.get("deadline_date") and row.get("deadline_type"):
@@ -79,6 +77,10 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
                 )
                 seen_deadlines.add(key)
 
+    # -- Step 3: get optional hearing_notes
+    NOTES_NA = "\nNotes: N/A"
+    NOTES_NA_HTML = "<br><b>Notes:</b> N/A"
+
     if h.get("notes"):
         parts.append(f"\nNotes: {h['notes']}")
         html_parts.append(f"<br><b>Notes:</b> {h['notes']}")
@@ -86,9 +88,11 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
         parts.append(NOTES_NA)
         html_parts.append(NOTES_NA_HTML)
 
-    # Bills — skip rows where bill data is entirely null (hearing with no bills)
+    # -- Step 4: bills — skip rows if no bill-related data present
     bills = [r for r in rows if r.get("bill_number")]
     agenda_length = len(bills)
+    footnote_content = dict()
+
     if bills:
         # Filter only for tracked bills
         tracked_bills = [r for r in bills if r.get("on_dashboard", False)]
@@ -100,21 +104,46 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
 
         # Only format content for tracked bills
         for bill_detail in tracked_bills:
+            if bill_detail['footnote_symbol']:
+                symbol = bill_detail['footnote_symbol']
+                footnote = bill_detail['footnote']
+                logger.info(f"Found footnote and symbol: {symbol} - {footnote}")
+                footnote_content[symbol] = footnote
+            else:
+                symbol = ""
+
             # Ex: AB 123 - Titile (File order: 4/5)
             line = (
                 "-"
-                f" {bill_detail['bill_number']} |"
+                f" {bill_detail['bill_number']}{symbol} |" # Add footnote symbol if exists
                 f" {bill_detail['bill_name']} |"
                 f" File order: {bill_detail['file_order']}/{agenda_length}"
             )
-
+            logger.info(line)
             # Add content to description parts, stripping excess whitespace
             parts.append(line)
             html_parts.append(f"<li>{line[2:]}</li>")
         html_parts.append("</ul>")
 
+    # -- Step 5: optionally, join footnote description to the bottom if exists
+    if footnote_content:
+        logger.info("description step 5")
+        footnote_description = "\n\n----------\n"
+        footnote_description_html = "<br><br>----------<br>"
+
+        for symbol, footnote in footnote_content.items():
+            line = f"{symbol}{footnote}"
+            footnote_description += f"{line}\n"
+            footnote_description_html += f"<p>{line}</p>"
+
+        logger.info(footnote_description)
+        parts.append(footnote_description)
+        html_parts.append(footnote_description_html)
+
+    # -- Step 6: Join parts
     plain = "\n".join(parts)
     html = f'<html><body>{"".join(html_parts)}</body></html>'
+    
     return plain, html
 
 
@@ -169,9 +198,9 @@ def build_hearing_event(
     # Build event summary (title) from hearing-level fields
     prefix = _chamber_prefix(h.get("chamber_id"))
     hearing_name = h.get("hearing_name") or f"Hearing {hearing_id}"
-    summary = f"{prefix} {hearing_name}".strip() if prefix else hearing_name
+    summary = f"{prefix} {hearing_name}"
     ev.add("summary", summary)
-
+    logger.info(f"Building {summary}")
     # Build description from all rows in the group
     plain, html = _build_description(h, group_rows)
     ev.add("description", plain)

--- a/calendar-feed/hearing_builder.py
+++ b/calendar-feed/hearing_builder.py
@@ -104,9 +104,9 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
 
         # Only format content for tracked bills
         for bill_detail in tracked_bills:
-            if bill_detail['footnote_symbol']:
-                symbol = bill_detail['footnote_symbol']
-                footnote = bill_detail['footnote']
+            if bill_detail["footnote_symbol"]:
+                symbol = bill_detail["footnote_symbol"]
+                footnote = bill_detail["footnote"]
                 logger.info(f"Found footnote and symbol: {symbol} - {footnote}")
                 footnote_content[symbol] = footnote
             else:
@@ -115,7 +115,7 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
             # Ex: AB 123 - Titile (File order: 4/5)
             line = (
                 "-"
-                f" {bill_detail['bill_number']}{symbol} |" # Add footnote symbol if exists
+                f" {bill_detail['bill_number']}{symbol} |"  # Add footnote symbol if exists
                 f" {bill_detail['bill_name']} |"
                 f" File order: {bill_detail['file_order']}/{agenda_length}"
             )
@@ -143,7 +143,7 @@ def _build_description(h: dict, rows: list[dict]) -> tuple[str, str]:
     # -- Step 6: Join parts
     plain = "\n".join(parts)
     html = f'<html><body>{"".join(html_parts)}</body></html>'
-    
+
     return plain, html
 
 

--- a/calendar-feed/ics_builder.py
+++ b/calendar-feed/ics_builder.py
@@ -88,7 +88,11 @@ def build_ical(
                 if group:  # Only try to build deadlines if group has data
                     for row in group:
                         # Check for missing data; continue to next bill if invalid
-                        if not row.get("on_dashboard") or not row.get("deadline_date") and not row.get("canceled_at"):
+                        if (
+                            not row.get("on_dashboard")
+                            or not row.get("deadline_date")
+                            and not row.get("canceled_at")
+                        ):
                             continue
 
                         # Check if org position warrants building a deadline; continue to next bill if invalid

--- a/calendar-feed/ics_builder.py
+++ b/calendar-feed/ics_builder.py
@@ -79,6 +79,8 @@ def build_ical(
     try:
         for hearing_id, group in group_hearings(rows):
             try:
+                if group[0].get("canceled_at"):
+                    continue
                 hearing_event = build_hearing_event(now_utc, hearing_id, group)
                 cal.add_component(hearing_event)
                 hearing_count += 1
@@ -86,7 +88,7 @@ def build_ical(
                 if group:  # Only try to build deadlines if group has data
                     for row in group:
                         # Check for missing data; continue to next bill if invalid
-                        if not row.get("on_dashboard") or not row.get("deadline_date"):
+                        if not row.get("on_dashboard") or not row.get("deadline_date") and not row.get("canceled_at"):
                             continue
 
                         # Check if org position warrants building a deadline; continue to next bill if invalid

--- a/calendar-feed/warm_cache.py
+++ b/calendar-feed/warm_cache.py
@@ -1,38 +1,31 @@
 import requests
 import time
-import psycopg2
 from datetime import datetime
-from db.config import config
-
+from db.connect import get_conn
 
 def get_all_tokens():
     """Fetch ALL user and org feed tokens from database with debug info"""
-    params = config("postgres")
-    conn = psycopg2.connect(**params)
-    cur = conn.cursor()
+    with get_conn() as conn:
+        cur = conn.cursor()
+        # Get all users with their dashboard status
+        cur.execute("""
+            SELECT u.feed_token, u.email, u.ai_working_group
+            FROM auth.approved_users u
+            LEFT JOIN app.user_bill_dashboard ub ON u.email = ub.user_email
+            WHERE u.feed_token IS NOT NULL
+            GROUP BY u.email, u.ai_working_group, u.feed_token
+        """)
+        users = [(row[0], row[1], row[2]) for row in cur.fetchall()]
 
-    # Get all users with their dashboard status
-    cur.execute("""
-        SELECT u.feed_token, u.email, u.ai_working_group
-        FROM auth.approved_users u
-        LEFT JOIN app.user_bill_dashboard ub ON u.email = ub.user_email
-        WHERE u.feed_token IS NOT NULL
-        GROUP BY u.email, u.ai_working_group, u.feed_token
-    """)
-    users = [(row[0], row[1], row[2]) for row in cur.fetchall()]
-
-    # Get all orgs with their dashboard status
-    cur.execute("""
-        SELECT o.feed_token, o.name
-        FROM auth.approved_organizations o
-        LEFT JOIN app.org_bill_dashboard ob ON o.id = ob.org_id
-        WHERE o.feed_token IS NOT NULL
-        GROUP BY o.id, o.name, o.feed_token
-    """)
-    orgs = [(row[0], row[1]) for row in cur.fetchall()]
-
-    cur.close()
-    conn.close()
+        # Get all orgs with their dashboard status
+        cur.execute("""
+            SELECT o.feed_token, o.name
+            FROM auth.approved_organizations o
+            LEFT JOIN app.org_bill_dashboard ob ON o.id = ob.org_id
+            WHERE o.feed_token IS NOT NULL
+            GROUP BY o.id, o.name, o.feed_token
+        """)
+        orgs = [(row[0], row[1]) for row in cur.fetchall()]
 
     return users, orgs
 
@@ -53,7 +46,6 @@ def warm_endpoint(endpoint_type, name, url):
 def warm_cache():
     print("Fetching ALL feed tokens from database...")
     users, orgs = get_all_tokens()
-
     print(f"Warming cache for {len(users)} users and {len(orgs)} orgs")
     print(f"Started at: {datetime.now().strftime('%H:%M:%S')}")
 

--- a/calendar-feed/warm_cache.py
+++ b/calendar-feed/warm_cache.py
@@ -3,28 +3,33 @@ import time
 from datetime import datetime
 from db.connect import get_conn
 
+
 def get_all_tokens():
     """Fetch ALL user and org feed tokens from database with debug info"""
     with get_conn() as conn:
         cur = conn.cursor()
         # Get all users with their dashboard status
-        cur.execute("""
+        cur.execute(
+            """
             SELECT u.feed_token, u.email, u.ai_working_group
             FROM auth.approved_users u
             LEFT JOIN app.user_bill_dashboard ub ON u.email = ub.user_email
             WHERE u.feed_token IS NOT NULL
             GROUP BY u.email, u.ai_working_group, u.feed_token
-        """)
+        """
+        )
         users = [(row[0], row[1], row[2]) for row in cur.fetchall()]
 
         # Get all orgs with their dashboard status
-        cur.execute("""
+        cur.execute(
+            """
             SELECT o.feed_token, o.name
             FROM auth.approved_organizations o
             LEFT JOIN app.org_bill_dashboard ob ON o.id = ob.org_id
             WHERE o.feed_token IS NOT NULL
             GROUP BY o.id, o.name, o.feed_token
-        """)
+        """
+        )
         orgs = [(row[0], row[1]) for row in cur.fetchall()]
 
     return users, orgs

--- a/db/calendar_queries.py
+++ b/db/calendar_queries.py
@@ -24,17 +24,19 @@ _FEED_SELECT = """
         h.chamber_id,
         h.committee_id,
         h.updated_at,
+        h.canceled_at,
         c.webpage_link      AS committee_webpage,
         hd.deadline_date,
         hd.deadline_type,
         b.openstates_bill_id,
-        b.bill_num          AS bill_number,
-        b.title             AS bill_name
+        b.bill_number,
+        b.bill_name,
+        b.author            AS bill_author
     FROM snapshot.hearings h
     LEFT JOIN snapshot.committee         c  ON c.committee_id = h.committee_id
     LEFT JOIN snapshot.hearing_deadlines hd ON hd.hearing_id = h.hearing_id
     LEFT JOIN snapshot.hearing_bills     hb ON hb.hearing_id = h.hearing_id
-    LEFT JOIN snapshot.bill               b ON b.openstates_bill_id = hb.openstates_bill_id
+    LEFT JOIN app.bills_mv               b ON b.openstates_bill_id = hb.openstates_bill_id
 """
 
 # Extended SELECT for dashboard feeds — adds on_dashboard flag per bill row.
@@ -55,24 +57,26 @@ _DASHBOARD_SELECT_BASE = """
         h.chamber_id,
         h.committee_id,
         h.updated_at,
+        h.canceled_at,
         c.webpage_link      AS committee_webpage,
         hd.deadline_date,
         hd.deadline_type,
         b.openstates_bill_id,
-        b.bill_num          AS bill_number,
-        b.title             AS bill_name,
+        b.bill_number,
+        b.bill_name,
         hb.file_order,
+        hb.footnote,
+        hb.footnote_symbol,
         CASE WHEN dash.openstates_bill_id IS NOT NULL
              THEN TRUE ELSE FALSE
         END                 AS on_dashboard,
         -- Author from bills materialized view
-        bmv.author          AS bill_author
+        b.author          AS bill_author
     FROM snapshot.hearings h
     LEFT JOIN snapshot.committee         c  ON c.committee_id = h.committee_id
     LEFT JOIN snapshot.hearing_deadlines hd ON hd.hearing_id = h.hearing_id
     LEFT JOIN snapshot.hearing_bills     hb ON hb.hearing_id = h.hearing_id
-    LEFT JOIN snapshot.bill               b ON b.openstates_bill_id = hb.openstates_bill_id
-    LEFT JOIN app.bills_mv              bmv ON bmv.openstates_bill_id = b.openstates_bill_id
+    LEFT JOIN app.bills_mv               b ON b.openstates_bill_id = hb.openstates_bill_id
 """
 
 # Extended template with org_position (for org feeds only)
@@ -91,25 +95,27 @@ _DASHBOARD_SELECT_WITH_CUSTOM = """
         h.chamber_id,
         h.committee_id,
         h.updated_at,
+        h.canceled_at,
         c.webpage_link      AS committee_webpage,
         hd.deadline_date,
         hd.deadline_type,
         b.openstates_bill_id,
-        b.bill_num          AS bill_number,
-        b.title             AS bill_name,
+        b.bill_number,
+        b.bill_name,
         hb.file_order,
+        hb.footnote,
+        hb.footnote_symbol,
         CASE WHEN dash.openstates_bill_id IS NOT NULL
              THEN TRUE ELSE FALSE
         END                 AS on_dashboard,
-        bmv.author          AS bill_author,
+        b.author          AS bill_author,
         bcd.org_position
     FROM snapshot.hearings h
     LEFT JOIN snapshot.committee         c  ON c.committee_id = h.committee_id
     LEFT JOIN snapshot.hearing_deadlines hd ON hd.hearing_id = h.hearing_id
     LEFT JOIN snapshot.hearing_bills     hb ON hb.hearing_id = h.hearing_id
-    LEFT JOIN snapshot.bill               b ON b.openstates_bill_id = hb.openstates_bill_id
-    LEFT JOIN app.bills_mv              bmv ON bmv.openstates_bill_id = b.openstates_bill_id
-    LEFT JOIN app.bill_custom_details    bcd ON bcd.openstates_bill_id = b.openstates_bill_id
+    LEFT JOIN app.bills_mv               b ON b.openstates_bill_id = hb.openstates_bill_id
+    LEFT JOIN app.bill_custom_details    bcd ON bcd.openstates_bill_id = hb.openstates_bill_id
                                             AND bcd.last_updated_org_id = %s
 """
 

--- a/db/migrations/004_hearing_audit_upsert_support.sql
+++ b/db/migrations/004_hearing_audit_upsert_support.sql
@@ -80,7 +80,5 @@ COMMIT;
 -- ALTER TABLE snapshot.hearing_bills DROP CONSTRAINT IF EXISTS uq_hearing_bills_hearing_bill;
 -- ALTER TABLE snapshot.hearings DROP CONSTRAINT IF EXISTS uq_hearings_chamber_name_date;
 
--- -- Don't restore rows - just note they were deleted
--- -- You may want to log this for audit purposes
 -- COMMIT;
 -- =============================================================================

--- a/db/migrations/004_hearing_audit_upsert_support.sql
+++ b/db/migrations/004_hearing_audit_upsert_support.sql
@@ -52,6 +52,19 @@ FOR EACH ROW EXECUTE FUNCTION snapshot.update_hearing_updated_at();
 -- Trigger function: update hearings.updated_at when any child hearing_bills row
 -- is inserted, updated, or deleted
 -- COALESCE handles the null NEW (on DELETE) and null OLD (on INSERT) cases
+CREATE OR REPLACE FUNCTION snapshot.touch_hearing_on_bill_change()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE snapshot.hearings
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE hearing_id = COALESCE(NEW.hearing_id, OLD.hearing_id);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+ 
+CREATE TRIGGER trg_hearing_bills_touch_parent
+AFTER INSERT OR UPDATE OR DELETE ON snapshot.hearing_bills
+FOR EACH ROW EXECUTE FUNCTION snapshot.touch_hearing_on_bill_change();
 
 COMMIT;
 

--- a/db/migrations/004_hearing_audit_upsert_support.sql
+++ b/db/migrations/004_hearing_audit_upsert_support.sql
@@ -1,0 +1,62 @@
+-- =============================================================================
+-- Migration: Add constraints, columns and triggers to support upsert + better
+--            database auditing
+-- Run once against legtracker_2026
+-- =============================================================================
+
+BEGIN;
+
+-- Manually delete problematic rows from hearing_bills to be restored later
+DELETE FROM snapshot.hearing_bills WHERE id=602;
+DELETE FROM snapshot.hearing_bills WHERE id=861;
+
+-- Natural key for hearings: chamber, name, date
+ALTER TABLE snapshot.hearings
+    ADD CONSTRAINT uq_hearings_chamber_name_date
+    UNIQUE(chamber_id, name, date);
+
+-- Natural key for hearing_bills: hearing_id, bill_id
+ALTER TABLE snapshot.hearing_bills
+    ADD CONSTRAINT uq_hearing_bills_hearing_bill
+    UNIQUE(hearing_id, openstates_bill_id);
+
+-- New column for hearings to record cancellation rather than dropping rows
+ALTER TABLE snapshot.hearings
+    ADD COLUMN canceled_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Trigger function: update hearings.updated_at on meaningful column changes
+-- Excludes derived columns (committee_id, chamber_id, created_at)
+CREATE OR REPLACE FUNCTION snapshot.update_hearing_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (
+        NEW.time_verbatim       IS DISTINCT FROM OLD.time_verbatim OR
+        NEW.time_normalized     IS DISTINCT FROM OLD.time_normalized OR
+        NEW.is_allday           IS DISTINCT FROM OLD.is_allday OR
+        NEW.location            IS DISTINCT FROM OLD.location OR
+        NEW.room                IS DISTINCT FROM OLD.room OR
+        NEW.notes               IS DISTINCT FROM OLD.notes OR
+        NEW.canceled_at         IS DISTINCT FROM OLD.canceled_at
+    ) THEN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+ 
+CREATE TRIGGER trg_hearings_updated_at
+BEFORE UPDATE ON snapshot.hearings
+FOR EACH ROW EXECUTE FUNCTION snapshot.update_hearing_updated_at();
+
+
+-- Trigger function: update hearings.updated_at when any child hearing_bills row
+-- is inserted, updated, or deleted
+-- COALESCE handles the null NEW (on DELETE) and null OLD (on INSERT) cases
+
+COMMIT;
+
+-- =============================================================================
+-- NOTE: This migration intentionally does NOT backfill tokens.
+-- Run scripts/generate_tokens.py after applying this migration.
+-- That script prints raw tokens to stdout (once) and stores only the hash here.
+-- =============================================================================

--- a/db/migrations/004_hearing_audit_upsert_support.sql
+++ b/db/migrations/004_hearing_audit_upsert_support.sql
@@ -69,7 +69,18 @@ FOR EACH ROW EXECUTE FUNCTION snapshot.touch_hearing_on_bill_change();
 COMMIT;
 
 -- =============================================================================
--- NOTE: This migration intentionally does NOT backfill tokens.
--- Run scripts/generate_tokens.py after applying this migration.
--- That script prints raw tokens to stdout (once) and stores only the hash here.
+-- ROLLBACK
+-- BEGIN;
+
+-- DROP TRIGGER IF EXISTS trg_hearing_bills_touch_parent ON snapshot.hearing_bills;
+-- DROP FUNCTION IF EXISTS snapshot.touch_hearing_on_bill_change();
+-- DROP TRIGGER IF EXISTS trg_hearings_updated_at ON snapshot.hearings;
+-- DROP FUNCTION IF EXISTS snapshot.update_hearing_updated_at();
+-- ALTER TABLE snapshot.hearings DROP COLUMN IF EXISTS canceled_at;
+-- ALTER TABLE snapshot.hearing_bills DROP CONSTRAINT IF EXISTS uq_hearing_bills_hearing_bill;
+-- ALTER TABLE snapshot.hearings DROP CONSTRAINT IF EXISTS uq_hearings_chamber_name_date;
+
+-- -- Don't restore rows - just note they were deleted
+-- -- You may want to log this for audit purposes
+-- COMMIT;
 -- =============================================================================

--- a/db/migrations/005_add_bill_footnote.sql
+++ b/db/migrations/005_add_bill_footnote.sql
@@ -7,7 +7,7 @@ BEGIN;
 
 -- New column for hearing_bills to record special footnotes
 ALTER TABLE snapshot.hearing_bills
-    ADD COLUMN footnote TEXT DEFAULT NULL;
+    ADD COLUMN footnote TEXT DEFAULT NULL,
     ADD COLUMN footnote_symbol CHAR(1) DEFAULT NULL;
 
 COMMIT;

--- a/db/migrations/005_add_bill_footnote.sql
+++ b/db/migrations/005_add_bill_footnote.sql
@@ -13,6 +13,7 @@ ALTER TABLE snapshot.hearing_bills
 COMMIT;
 
 -- =============================================================================
--- ROLLBACK
+-- -- ROLLBACK
 -- ALTER TABLE snapshot.hearing_bills DROP COLUMN IF EXISTS footnote;
+-- ALTER TABLE snapshot.hearing_bills DROP COLUMN IF EXISTS footnote_symbol;
 -- =============================================================================

--- a/db/migrations/005_add_bill_footnote.sql
+++ b/db/migrations/005_add_bill_footnote.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration: Add footnotes to hearing_bills to better represent hearing info
+-- Run once against legtracker_2026
+-- =============================================================================
+
+BEGIN;
+
+-- New column for hearing_bills to record special footnotes
+ALTER TABLE snapshot.hearing_bills
+    ADD COLUMN footnote TEXT DEFAULT NULL;
+    ADD COLUMN footnote_symbol CHAR(1) DEFAULT NULL;
+
+COMMIT;
+
+-- =============================================================================
+-- ROLLBACK
+-- ALTER TABLE snapshot.hearing_bills DROP COLUMN IF EXISTS footnote;
+-- =============================================================================


### PR DESCRIPTION
`calendar-feed` service
- Canceled hearings are filtered from feeds
- Event descriptions include footnote information
- `warm_cache.py` DB connection method aligned with the rest of the service

`db` service
- `calendar_queries.py` including new columns + unified joins from bills mat view instead of snapshot
- `migrations/` includes new columns + triggers