### PR TITLE
change materialized views to regular views for the cal page

### DIFF
--- a/app/db/sql/views/process_hearing_bills_view.sql
+++ b/app/db/sql/views/process_hearing_bills_view.sql
@@ -1,0 +1,21 @@
+-- Title: process_hearing_bills_view.sql
+-- Creates app.hearing_bills view
+-- One row per bill per hearing
+-- Sources: snapshot.hearing_bills, app.bills_mv
+
+DROP VIEW IF EXISTS app.hearing_bills;
+CREATE VIEW app.hearing_bills AS
+SELECT
+    hb.hearing_id,
+    hb.openstates_bill_id,
+    hb.file_order,
+    hb.footnote,
+    hb.footnote_symbol,
+    bm.bill_number,
+    bm.bill_name,
+    bm.status,
+    bm.date_introduced,
+    bm.author         AS bill_author,
+    bm.leginfo_link
+FROM snapshot.hearing_bills hb
+LEFT JOIN app.bills_mv bm ON bm.openstates_bill_id = hb.openstates_bill_id;

--- a/app/db/sql/views/process_hearing_deadlines_view.sql
+++ b/app/db/sql/views/process_hearing_deadlines_view.sql
@@ -1,0 +1,18 @@
+-- Title: process_hearing_deadlines_view.sql
+-- Creates app.hearing_deadlines view
+-- One row per deadline per hearing
+-- Sources: snapshot.hearing_deadlines, snapshot.hearings
+
+DROP VIEW IF EXISTS app.hearing_deadlines;
+CREATE VIEW app.hearing_deadlines AS
+SELECT
+    hd.id,
+    hd.hearing_id,
+    hd.deadline_date,
+    hd.deadline_type,
+    h.date           AS hearing_date,
+    h.name           AS hearing_name,
+    h.chamber_id,
+    h.committee_id
+FROM snapshot.hearing_deadlines hd
+JOIN snapshot.hearings h ON h.hearing_id = hd.hearing_id;

--- a/app/db/sql/views/process_hearings_view.sql
+++ b/app/db/sql/views/process_hearings_view.sql
@@ -1,0 +1,25 @@
+-- Title: process_hearings_view.sql
+-- Creates app.hearings view (not a materialized view)
+-- This is a stopgap until we can add the hearings MVs refresh to the daily update 
+-- One row per hearing (no bill data)
+-- Sources: snapshot.hearings, snapshot.hearing_deadlines
+
+DROP VIEW IF EXISTS app.hearings;
+CREATE VIEW app.hearings AS
+SELECT
+    h.hearing_id,
+    h.date           AS hearing_date,
+    h.name           AS hearing_name,
+    h.time_verbatim  AS hearing_time_verbatim,
+    h.time_normalized AS hearing_time,
+    h.is_allday,
+    h.location       AS hearing_location,
+    h.room           AS hearing_room,
+    h.chamber_id,
+    h.committee_id,
+    h.canceled_at,
+    h.created_at,
+    h.updated_at
+FROM snapshot.hearings h;
+
+

--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -425,9 +425,11 @@ def create_ics_file(events):
 @st.cache_data(show_spinner="Loading committee events and deadlines...",ttl=120) # Cache data and refresh every 2 mins
 @profile("Calendar - load committee events and deadlines")
 def load_committee_events():
-    hearings = query_table('app', 'hearings_mv')
-    hearing_bills = query_table('app', 'hearing_bills_mv')
-    hearing_deadlines = query_table('app', 'hearing_deadlines_mv')
+    # Pull VIEWS from the database
+    #TODO: switch to existing materialized views when refresh is added to daily update scripts
+    hearings = query_table('app', 'hearings')
+    hearing_bills = query_table('app', 'hearing_bills')
+    hearing_deadlines = query_table('app', 'hearing_deadlines')
 
     # Format date cols as date string without time for display purposes
     hearings['hearing_date'] = pd.to_datetime(hearings['hearing_date'])


### PR DESCRIPTION
- app.hearings
- app.hearing_bills
- app.hearing_deadlines

Switch back to MVs once we include refresh for them in the daily update scripts in ca-leg-tracker