### PR TITLE
Improved org dashboard behavior

### DIFF
--- a/app/db/query.py
+++ b/app/db/query.py
@@ -423,6 +423,7 @@ def remove_bill_from_org_dashboard(openstates_bill_id, bill_number):
 
     # Clear the cache so data reloads -- only for org dashboard bills, not the entire cache which could impact other areas of the app
     get_org_dashboard_bills.clear()
+    get_bill_activity_history.clear()
 
 ###############################################################################
 @st.cache_data(ttl=10) 

--- a/app/org_dashboard.py
+++ b/app/org_dashboard.py
@@ -43,13 +43,6 @@ st.expander("About this page", icon="ℹ️", expanded=False).markdown(f"""
 st.markdown(" ")
 st.markdown(" ")
 
-# Display any pending toast message from a previous rerun
-if '_toast' in st.session_state:
-    st.toast(st.session_state.pop('_toast'), icon='✅')
-
-if '_toast_warning' in st.session_state:
-    st.toast(st.session_state.pop('_toast_warning'), icon='⚠️')
-
 # Clear dashboard button -- DISABLED FOR NOW BC IT MIGHT GET MESSY HAVING THIS OPTION WITH MANY USERS SHARING ONE ORG DASHBOARD. but if we want to add it, the clear button on the my dashboard works.
 #col1, col2 = st.columns([4, 1])
 #with col2:
@@ -92,9 +85,7 @@ filters = display_bill_filters(
     show_org_position=True,
     show_assigned_to=True
 )
-filtered_bills = apply_bill_filters(st.session_state.org_dashboard_bills, filter_dict=filters)
-
-
+st.session_state['filtered_bills'] = apply_bill_filters(st.session_state.org_dashboard_bills, filter_dict=filters)
 # Create a hash of the filters to detect changes and reset selected bill if filters change. 
 # We use a hash here because the filter dict can be complex and contain unhashable types, so we convert it to a JSON string first (with sorted keys for consistency) and then hash that string.
 current_hash = filters_hash(filters)
@@ -105,48 +96,38 @@ if st.session_state.get('_last_filter_hash') != current_hash:
 # Update total bills count
 col1, col2, col3 = st.columns([2, 6, 2])
 with col1:
-    total_bills = len(filtered_bills)
+    total_bills = len(st.session_state.filtered_bills)
     st.markdown(f"#### Total bills: {total_bills:,}")
-    if len(filtered_bills) < len(st.session_state.org_dashboard_bills):
+    if len(st.session_state.filtered_bills) < len(st.session_state.org_dashboard_bills):
         st.caption(f"(filtered from {len(st.session_state.org_dashboard_bills):,} total)")
 
 ############################ MAIN TABLE / DATAFRAME #############################
 
+# Case 1: there are tracked bills
 if not st.session_state.org_dashboard_bills.empty:
     with timer("Org dashboard - draw streamlit df"):
-        data = display_bills_table(filtered_bills)
+        data = display_bills_table(st.session_state.filtered_bills)
+        selected = data.selection
+        # Case 1A: a row has been selected
+        if selected.rows:
+            selected_index = selected.rows[0]
+            # Update the session state with the newly selected ID
+            newly_selected_id = st.session_state.filtered_bills.iloc[selected_index]['openstates_bill_id']
+            if newly_selected_id != st.session_state.get('selected_bill_id', None):
+                track_event("selected bill ID updated")
+                st.session_state['selected_bill_id'] = newly_selected_id
+        # Case 1B: no row is selected, so we clear the saved bill ID
+        else:
+            track_event("selected bill ID cleared")
+            st.session_state.pop('selected_bill_id', None)
 
-    selected = data.selection
+        # Always check if there is a saved bill ID
+        selected_id = st.session_state.get('selected_bill_id')
+        # Case 2: the saved bill ID is not None
+        if selected_id is not None:
+            display_org_dashboard_details(selected_id)
 
-    if selected is not None and selected.rows:
-        track_event("Row selected")
-        selected_index = selected.rows[0]
-        newly_selected_id = filtered_bills.iloc[selected_index]['openstates_bill_id']
-        
-        # If user switched to a different bill, bust the custom details cache
-        # so the form loads fresh data for the new bill rather than serving
-        # the previous bill's cached response
-        if newly_selected_id != st.session_state.get('selected_bill_id'):
-            get_custom_bill_details_with_timestamp.clear()
-        
-        # Persist selection by bill ID (not row index) so it survives reruns
-        st.session_state['selected_bill_id'] = newly_selected_id
-
-    else:
-        # No row selected (deselect or initial load) — clear the details panel
-        st.session_state.pop('selected_bill_id', None)
-
-    # Look up the selected bill by ID from session state.
-    # Using ID instead of row index means the correct bill stays selected
-    # even if the table re-sorts or filters change between reruns.
-    selected_id = st.session_state.get('selected_bill_id')
-    if selected_id is not None:
-        selected_bill_data = filtered_bills[
-            filtered_bills['openstates_bill_id'] == selected_id
-        ]
-        if not selected_bill_data.empty:
-            display_org_dashboard_details(selected_bill_data)
-
+# Case 3: there are no tracked bills
 elif st.session_state.org_dashboard_bills.empty:
     st.write('No bills added yet.')
 

--- a/app/utils/org_dashboard.py
+++ b/app/utils/org_dashboard.py
@@ -16,14 +16,27 @@ from .profiling import profile, timer, logging
 logger = logging.getLogger(__name__)
 
 @profile("utils/org_dashboard.py - display_org_dashboard_details")
-def display_org_dashboard_details(selected_rows):
+@st.fragment # Allows us to rerun 
+def display_org_dashboard_details(selected_id):
     '''
     Displays bill details on the ORG DASHBOARD page when a row is selected; features a button to remove a bill from your dashboard.
     '''
     # Check if selected_rows is None or empty before proceeding
-    if selected_rows is None or selected_rows.empty:
+    if selected_id is None:
         return
     
+    # Display any pending toast message from a previous rerun
+    if '_toast' in st.session_state:
+        st.toast(st.session_state.pop('_toast'), icon='✅')
+
+    if '_toast_warning' in st.session_state:
+        st.toast(st.session_state.pop('_toast_warning'), icon='⚠️')
+    
+    # NOTE: fetch fresh data inside the fragment so cache clears work
+    selected_rows = st.session_state.filtered_bills[
+        st.session_state.filtered_bills['openstates_bill_id'] == selected_id
+    ]
+
     required_cols = ['openstates_bill_id', 'bill_number', 
                         'bill_name', 'author', 'coauthors', 'status', 'date_introduced', 
                         'leg_session', 'chamber', 'leginfo_link', 'bill_text', 
@@ -93,10 +106,9 @@ def display_org_dashboard_details(selected_rows):
                     
                     # Reset org dashboard bills session state
                     st.session_state.org_dashboard_bills = pd.DataFrame()
-
-                    # Show success message, then refresh app to reflect change
+                    # Show success message, then refresh fragment to reflect change
                     st.session_state['_toast'] = f"Bill {bill_number} removed from dashboard."
-                    st.rerun()
+                    st.rerun(scope="fragment")
 
     # Add empty rows of space  
     st.write("")
@@ -322,6 +334,7 @@ def display_org_dashboard_details(selected_rows):
         if submitted:
             try:
                 # Update function call if needed
+                # Handles select + insert from DB and clearing cached data
                 save_custom_bill_details_with_timestamp( 
                     bill_number, 
                     org_position, 
@@ -335,15 +348,11 @@ def display_org_dashboard_details(selected_rows):
                     org_id,
                     org_name
                 )
-                
-                # When form is submitted, clear the cached org dashboard bills data so that it will be refreshed with the new custom details when the user clicks on a bill again or when the dashboard reloads. This ensures that the user sees the most up-to-date information without having to manually refresh the page.
-                st.session_state.org_dashboard_bills = pd.DataFrame()
-                get_org_dashboard_bills.clear()
 
                 # Keep expander open after submission so user can see the updated details and message
                 st.session_state['expander_custom_details'] = True 
                 st.session_state['_toast'] = f"Custom details for bill {bill_number} saved successfully by {user_email} from {org_name}."
-                st.rerun() 
+                st.rerun(scope="fragment")
             except Exception as e:
                 st.error(f"Error saving details: {str(e)}")
         
@@ -375,9 +384,9 @@ def display_org_dashboard_details(selected_rows):
                 # Keep the expander open after submission so user can see the new letter in the history and message
                 st.session_state['expander_letter_history'] = True
                     
-                # Success message, then rerun to update letter history with the new letter
+                # Success message, then rerun fragment to update letter history with the new letter
                 st.session_state['_toast'] = "Document successfully added!"
-                st.rerun()
+                st.rerun(scope="fragment")
                 
             except Exception as e:
                     st.error(f"Error adding letter: {str(e)}")
@@ -385,7 +394,7 @@ def display_org_dashboard_details(selected_rows):
             if add_letter_btn:  # only warn if they actually clicked the button
                 st.session_state['expander_letter_history'] = True  # keep expander open to show the warning
                 st.session_state['_toast_warning'] = "Please enter both a document name and URL."
-                st.rerun()
+                st.rerun(scope="fragment")
         
         st.divider()
         st.markdown('##### Documents')


### PR DESCRIPTION
- Use `@st.fragment` decorator to preserve data editor row selection after form submit
- Refactor toast notification configuration to `utils/org_dashboard` to stay within fragment scope
- Simplify main Org Dashboard page flow