### PR TITLE
Dev updates: Calendar committee hearings tab resolve None bills #426

### DIFF
--- a/app/calendar_page_v2.py
+++ b/app/calendar_page_v2.py
@@ -273,6 +273,7 @@ with tab1:
         hearing_text = "Committee Hearing" if total_hearings == 1 else "Committee Hearings"
         deadline_text = "Letter Deadline" if total_deadlines == 1 else "Letter Deadlines"
         st.caption(f"**Displaying:** 🏛️ {total_hearings} {hearing_text} | ✉️ {total_deadlines} {deadline_text}")
+        st.caption("🚫 ~Canceled hearing~ | ⭐ Tracked bill (any dashboard)")
     with col2:
         st.markdown('')
 
@@ -310,32 +311,40 @@ with tab1:
                             color=get_badge_color(chamber_id)
                         )
                     with col2:
-                        with st.expander(committee_name, expanded=filters_active):
+                        expander_text = committee_name
+                        # NOTE: make cancellation obvious from list view
+                        if h_row.get('notes').strip().lower() == 'hearing canceled':
+                            expander_text = f"🚫 ~{committee_name}~"
+                        with st.expander(expander_text, expanded=filters_active):
                             expander_col1, expander_col2 = st.columns([5, 5])
                             with expander_col1:
                                 st.caption(f"🏛️ {chamber_name} {committee_name} Committee")
                                 st.caption(f"📅 {friendly_date}")
+                                # NOTE: event details displayed as caption
+                                st.caption(f"""
+                                           {h_row.get('hearing_time') or h_row.get('hearing_time_verbatim')} - 
+                                           {h_row.get('hearing_location') or 'N/A'} - 
+                                           {h_row.get('hearing_room') or 'N/A'}
+                                           """)
                             with expander_col2:
                                 # Render notes if exists
                                 if h_row.get('notes'):
                                     # But if notes indicate hearing is canceled, show that prominently instead of the notes content
                                     if h_row.get('notes').strip().lower() == 'hearing canceled':
-                                        st.caption("⚠️ This hearing has been canceled.")
+                                        st.caption("🚫 This hearing has been canceled.")
                                     else:
                                         st.caption(f"📌 Notes: {h_row.get('notes')}")
                                 # Render webpage link if exists
                                 if h_row.get('committee_webpage'):
                                     st.caption(f"🔗 [Committee Webpage]({h_row.get('committee_webpage')})")
-
+                            #     """)   
                             if bills:
+                                st.divider()
                                 st.caption(f"📝 Bills on the agenda:")
-                                for bill_row in bills:
+                                # NOTE: sort bills by file_order
+                                for bill_row in sorted(bills, key=lambda b: int(b.get('file_order', 999))):
                                     render_bill(
-                                        bill_number=bill_row.get('bill_number', 'N/A'),
-                                        bill_name=bill_row.get('bill_name', 'N/A'),
-                                        hearing_row=h_row,
-                                        bill_row=bill_row,
-                                        deadline_row=deadline_row,
+                                        row=bill_row
                                     )
                             else:
                                 st.caption("*There are no bills on the agenda for this hearing.*")

--- a/app/calendar_page_v2.py
+++ b/app/calendar_page_v2.py
@@ -313,7 +313,7 @@ with tab1:
                     with col2:
                         expander_text = committee_name
                         # NOTE: make cancellation obvious from list view
-                        if h_row.get('notes').strip().lower() == 'hearing canceled':
+                        if h_row.get('notes', '').strip().lower() == 'hearing canceled':
                             expander_text = f"🚫 ~{committee_name}~"
                         with st.expander(expander_text, expanded=filters_active):
                             expander_col1, expander_col2 = st.columns([5, 5])

--- a/app/db/sql/materialized views/process_hearing_bills_mv.sql
+++ b/app/db/sql/materialized views/process_hearing_bills_mv.sql
@@ -5,24 +5,44 @@
 
 DROP MATERIALIZED VIEW IF EXISTS app.hearing_bills_mv;
 CREATE MATERIALIZED VIEW app.hearing_bills_mv AS
+
+-- Process bill sponsors to get primary author and coauthors
+WITH bill_authors AS (
+    SELECT 
+        openstates_bill_id,
+        MAX(CASE WHEN primary_author = 'True' THEN full_name END)               AS author,
+        STRING_AGG(CASE WHEN primary_author = 'False' THEN full_name END, ', ') AS coauthors
+    FROM snapshot.bill_sponsor
+    GROUP BY openstates_bill_id
+)
+
 SELECT
     hb.hearing_id,
     hb.openstates_bill_id,
     hb.file_order,
     hb.footnote,
     hb.footnote_symbol,
-    bm.bill_number,
-    bm.bill_name,
-    bm.status,
-    bm.date_introduced,
-    bm.author         AS bill_author,
-    bm.leginfo_link
+    b.bill_num          AS bill_number,
+    b.title             AS bill_name,
+    b.first_action_date AS date_introduced,
+    a.author            AS bill_author,
+    -- Dyanmically generate leginfo link by adding session + bill num to URL
+    -- TODO: get this from OpenStates directly...
+    CONCAT(
+            'https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=',
+            REPLACE(session, '-', ''), -- Convert YYYY-YYYY to YYYYYYYY
+            '0',
+            REPLACE(bill_num, ' ', '') -- Remove spaces from bill number
+        ) AS leginfo_link
 FROM snapshot.hearing_bills hb
-LEFT JOIN app.bills_mv bm ON bm.openstates_bill_id = hb.openstates_bill_id
+LEFT JOIN snapshot.bill b ON b.openstates_bill_id = hb.openstates_bill_id
+LEFT JOIN bill_authors a ON a.openstates_bill_id = hb.openstates_bill_id
+
 WITH DATA;
 
 CREATE UNIQUE INDEX idx_hearing_bills_pk ON app.hearing_bills_mv (hearing_id, openstates_bill_id);
 CREATE INDEX idx_hearing_bills_hearing ON app.hearing_bills_mv (hearing_id);
 CREATE INDEX idx_hearing_bills_bill ON app.hearing_bills_mv (openstates_bill_id);
+
 
 -- REFRESH MATERIALIZED VIEW CONCURRENTLY app.hearing_bills_mv;

--- a/app/utils/calendar_utils.py
+++ b/app/utils/calendar_utils.py
@@ -16,6 +16,7 @@ import pytz
 import numpy as np
 from ics import Calendar, Event
 from .profiling import profile
+from .general import safe_get
 import re
 from db.connect import get_connection
 
@@ -433,66 +434,57 @@ def load_committee_events():
     # Format date cols as date string without time for display purposes
     hearings['hearing_date'] = pd.to_datetime(hearings['hearing_date'])
     hearings['hearing_date'] = hearings['hearing_date'].dt.strftime('%Y-%m-%d')
+    hearings['hearing_time'] = hearings['hearing_time'].apply(
+        lambda t: None if t is None else t.strftime("%-I:%M %p")
+    )
 
     hearing_deadlines['deadline_date'] = pd.to_datetime(hearing_deadlines['deadline_date'])
     hearing_deadlines['deadline_date'] = hearing_deadlines['deadline_date'].dt.strftime('%Y-%m-%d')
 
     return hearings, hearing_bills, hearing_deadlines
 
+# NOTE: returns whether string is in a DF column, hardcoded to bill_number
+def tracked_bill(session_state_df, bill_number) -> bool:
+    return session_state_df['bill_number'].isin([bill_number]).any()
+
+# NOTE: add single icon for any dashboard tracking, could be changed
+def render_bill_label(row: pd.Series):
+    bill_number = safe_get(row, 'bill_number')
+    bill_label = f"**{bill_number}** — {safe_get(row, 'bill_name')}"
+    tracked_on = {
+        "org": tracked_bill(st.session_state.org_dashboard_bills, bill_number),
+        "my": tracked_bill(st.session_state.dashboard_bills, bill_number),
+        "wg": tracked_bill(st.session_state.wg_dashboard_bills, bill_number)
+    }
+    if any(tracked_on.values()):
+        bill_label = "⭐ " + bill_label
+    return bill_label
+
 # Function to render bills for each committee event         
-def render_bill(bill_number: str, bill_name: str, hearing_row: pd.Series, bill_row: pd.Series, deadline_row: pd.Series | None):
+def render_bill(row: pd.Series):
     """
     This function renders bills on the calendar page in the following fashion: 
     - Bills are nested within a committee event (as an expander)
     - Each bill has an associated popover button; when clicked, it displays event + bill details
 
     Args:
-        bill_number: bill number string
-        bill_name: bill name string  
-        hearing_row: row from hearings df (hearing_date, hearing_name, chamber_id, hearing_time, hearing_location, hearing_room)
-        bill_row: row from hearing_bills df (file_order, status, date_introduced)
+        row: row from hearing_bills df (file_order, status, date_introduced)
         deadline_row: row from hearing_deadlines df, or None if no deadline exists
     """
-    col_text, col_btn = st.columns([7, 3])
-
-    with col_text:
-        st.markdown(f"- **{bill_number}** — {bill_name}")
-
-    with col_btn:
-        with st.popover("View event details", width="stretch", type="secondary"):
-            st.markdown(f"#### {bill_number}")
-            st.markdown(f"**{bill_name}**")
-            st.divider()
-
-            chamber_id = hearing_row.get('chamber_id')
-            chamber_name = 'Assembly' if chamber_id == 1 else 'Senate' if chamber_id == 2 else 'Unknown'
-
-            # Event info
-            st.markdown("##### Event Details")
-            st.markdown(f"""
-                - **Committee:** {hearing_row.get('hearing_name')}
-                - **Chamber:** {chamber_name}
-                - **Date:** {hearing_row.get('hearing_date')}
-                - **Time:** {hearing_row.get('hearing_time')}
-                - **Location:** {hearing_row.get('hearing_location')}
-                - **Room:** {hearing_row.get('hearing_room')}
-                - **Agenda Order:** {bill_row.get('file_order') if bill_row is not None else 'N/A'}
-            """)
-
-            # Letter deadline
-            st.markdown("##### Letter Deadline")
-            if deadline_row is not None and pd.notna(deadline_row.get('deadline_date')):
-                st.markdown(str(deadline_row.get('deadline_date')))
-            else:
-                st.markdown("No deadline set.")
-
-            # Bill info
-            st.markdown("##### Bill Details")
-            st.markdown(f"""
-                - **Status:** {bill_row.get('status') if bill_row is not None else 'N/A'}
-                - **Date Introduced:** {bill_row.get('date_introduced') if bill_row is not None else 'N/A'}
-            """)
-
+    file_order, expander = st.columns([0.05, 0.95])
+    # NOTE: markdown file order
+    with file_order:
+        st.write(f"##### **{safe_get(row, 'file_order')}.**")
+    # NOTE: use expander for better display
+    with expander:
+        if row is not None:
+            bill_label = render_bill_label(row)
+            with st.expander(bill_label, width='stretch'):
+                st.markdown(f"""
+                    - **Date Introduced:** {safe_get(row, 'date_introduced')}
+                    - **Author:** {safe_get(row, 'bill_author')}
+                """)
+                st.caption(f"🔗 [**Leginfo.gov**]({safe_get(row, 'leginfo_link')})")
 
 # Function to apply badges to denote chamber
 def get_badge_color(chamber_id) -> str:

--- a/app/utils/general.py
+++ b/app/utils/general.py
@@ -87,6 +87,11 @@ def clean_markdown(text):
     return result
 ###############################################################################
 
+def safe_get(row, key, default='N/A'):
+    return row.get(key) or default
+
+###############################################################################
+
 def get_topic_color(topic):
     # Handle empty/null case first (returns light gray)
     if not topic or topic == "0":

--- a/db/migrations/008_join_snapshot_hearing_bills.sql
+++ b/db/migrations/008_join_snapshot_hearing_bills.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- Migration: Refactor app.hearing_bills_mv to reference snapshot.bill
+-- Run once against legtracker_2026
+-- Views affected: app.hearing_bills_mv
+-- =============================================================================
+
+BEGIN;
+DROP MATERIALIZED VIEW IF EXISTS app.hearing_bills_mv;
+CREATE MATERIALIZED VIEW app.hearing_bills_mv AS
+
+-- Process bill sponsors to get primary author and coauthors
+WITH bill_authors AS (
+    SELECT 
+        openstates_bill_id,
+        MAX(CASE WHEN primary_author = 'True' THEN full_name END)               AS author,
+        STRING_AGG(CASE WHEN primary_author = 'False' THEN full_name END, ', ') AS coauthors
+    FROM snapshot.bill_sponsor
+    GROUP BY openstates_bill_id
+)
+
+SELECT
+    hb.hearing_id,
+    hb.openstates_bill_id,
+    hb.file_order,
+    hb.footnote,
+    hb.footnote_symbol,
+    b.bill_num          AS bill_number,
+    b.title             AS bill_name,
+    b.first_action_date AS date_introduced,
+    a.author            AS bill_author,
+    -- Dyanmically generate leginfo link by adding session + bill num to URL
+    -- TODO: get this from OpenStates directly...
+    CONCAT(
+            'https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=',
+            REPLACE(session, '-', ''), -- Convert YYYY-YYYY to YYYYYYYY
+            '0',
+            REPLACE(bill_num, ' ', '') -- Remove spaces from bill number
+        ) AS leginfo_link
+FROM snapshot.hearing_bills hb
+LEFT JOIN snapshot.bill b ON b.openstates_bill_id = hb.openstates_bill_id
+LEFT JOIN bill_authors a ON a.openstates_bill_id = hb.openstates_bill_id
+
+WITH DATA;
+
+CREATE UNIQUE INDEX idx_hearing_bills_pk ON app.hearing_bills_mv (hearing_id, openstates_bill_id);
+CREATE INDEX idx_hearing_bills_hearing ON app.hearing_bills_mv (hearing_id);
+CREATE INDEX idx_hearing_bills_bill ON app.hearing_bills_mv (openstates_bill_id);
+
+REFRESH MATERIALIZED VIEW app.hearing_bills_mv;
+COMMIT;
+-- =============================================================================
+-- -- ROLLBACK
+-- BEGIN;
+-- DROP MATERIALIZED VIEW IF EXISTS app.hearing_bills_mv;
+-- CREATE MATERIALIZED VIEW app.hearing_bills_mv AS
+-- SELECT
+--     hb.hearing_id,
+--     hb.openstates_bill_id,
+--     hb.file_order,
+--     hb.footnote,
+--     hb.footnote_symbol,
+--     bm.bill_number,
+--     bm.bill_name,
+--     bm.status,
+--     bm.date_introduced,
+--     bm.author         AS bill_author,
+--     bm.leginfo_link
+-- FROM snapshot.hearing_bills hb
+-- LEFT JOIN app.bills_mv bm ON bm.openstates_bill_id = hb.openstates_bill_id
+-- WITH DATA;
+
+-- CREATE UNIQUE INDEX idx_hearing_bills_pk ON app.hearing_bills_mv (hearing_id, openstates_bill_id);
+-- CREATE INDEX idx_hearing_bills_hearing ON app.hearing_bills_mv (hearing_id);
+-- CREATE INDEX idx_hearing_bills_bill ON app.hearing_bills_mv (openstates_bill_id);
+
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY app.hearing_bills_mv;
+-- COMMIT;
+-- =============================================================================


### PR DESCRIPTION
- 008.... migration file updates app.hearing_bills_mv to reference snapshot.bill directly **_(this has been run in the db)_**
- app.hearing_bills_mv definition is updated to match migration
- Emoji indicators + legend for canceled hearings and tracked bills
- Bills displayed as expanders
